### PR TITLE
Fix logcapture formatting

### DIFF
--- a/nose/plugins/logcapture.py
+++ b/nose/plugins/logcapture.py
@@ -15,6 +15,7 @@ You can remove other installed logging handlers with the
 ``--logging-clear-handlers`` option.
 """
 
+import itertools
 import logging
 import threading
 from logging import Handler
@@ -255,5 +256,9 @@ class LogCapture(Plugin):
         return map(safe_str, self.handler.buffer)
 
     def addCaptureToErr(self, ev, records):
-        return '\n'.join([safe_str(ev), ln('>> begin captured logging <<')]
-                         ).join(records).join([ln('>> end captured logging <<')])
+        return '\n'.join(itertools.chain(
+            [safe_str(ev), ln('>> begin captured logging <<')],
+            records,
+            [ln('>> end captured logging <<')],
+        ))  
+


### PR DESCRIPTION
It was broken in bbd6d086b74acaa8fc739e75461bd13d2ec62dac. After that commit, it would apply str.join multiple times, each with the previous text as the separator. Since the final join only had one item, it would throw away all the text before it and only include ln('>> end captured logging <<') in the result.

Also, use a chaining iterator, rather than building up a new list as was done before bbd6d086b74acaa8fc739e75461bd13d2ec62dac.