### PR TITLE
Actually use the result from sort_list

### DIFF
--- a/nose/loader.py
+++ b/nose/loader.py
@@ -118,7 +118,7 @@ class TestLoader(unittest.TestLoader):
         if not cases and hasattr(testCaseClass, 'runTest'):
             cases = ['runTest']
         if self.sortTestMethodsUsing:
-            sort_list(cases, cmp_to_key(self.sortTestMethodsUsing))
+            cases = sort_list(cases, cmp_to_key(self.sortTestMethodsUsing))
         return cases
 
     def _haveVisited(self, path):
@@ -146,7 +146,7 @@ class TestLoader(unittest.TestLoader):
             paths_added = add_path(path, self.config)
 
         entries = os.listdir(path)
-        sort_list(entries, regex_last_key(self.config.testMatch))
+        entries = sort_list(entries, regex_last_key(self.config.testMatch))
         for entry in entries:
             # this hard-coded initial-dot test will be removed:
             # http://code.google.com/p/python-nose/issues/detail?id=82
@@ -330,8 +330,8 @@ class TestLoader(unittest.TestLoader):
                         test_classes.append(test)
                 elif isfunction(test) and self.selector.wantFunction(test):
                     test_funcs.append(test)
-            sort_list(test_classes, lambda x: x.__name__)
-            sort_list(test_funcs, func_lineno)
+            test_classes = sort_list(test_classes, lambda x: x.__name__)
+            test_funcs = sort_list(test_funcs, func_lineno)
             tests = map(lambda t: self.makeTest(t, parent=module),
                         test_classes + test_funcs)
 

--- a/nose/plugins/manager.py
+++ b/nose/plugins/manager.py
@@ -287,7 +287,7 @@ class PluginManager(object):
             self.addPlugin(plug)
 
     def sort(self):
-        return sort_list(self._plugins, lambda x: getattr(x, 'score', 1), reverse=True)
+        self._plugins = sort_list(self._plugins, lambda x: getattr(x, 'score', 1), reverse=True)
 
     def _get_plugins(self):
         return self._plugins

--- a/nose/util.py
+++ b/nose/util.py
@@ -495,7 +495,7 @@ def regex_last_key(regex):
     >>> c = Config()
     >>> regex = c.testMatch
     >>> entries = ['.', '..', 'a_test', 'src', 'lib', 'test', 'foo.py']
-    >>> sort_list(entries, regex_last_key(regex))
+    >>> entries = sort_list(entries, regex_last_key(regex))
     >>> entries
     ['.', '..', 'foo.py', 'lib', 'src', 'a_test', 'test']
     """


### PR DESCRIPTION
d57725e833ad8a8a1a4a5197b63456ca4104f04f changed sort_list so that it returns a new list, rather than sorting in place, however places using it would just throw the result away. And if an iterater was passed to it, it would now be empty.