### PR TITLE
Map extend

### DIFF
--- a/nose/case.py
+++ b/nose/case.py
@@ -333,7 +333,7 @@ class MethodTestCase(TestBase):
         if isfunction(method):
             raise ValueError(
                 "Unbound methods must be wrapped using pyversion.unbound_method before passing to MethodTestCase")
-        self.cls = method.im_class
+        self.cls = method.__self__.__class__
         self.inst = self.cls()
         if self.test is None:
             method_name = self.method.__name__

--- a/nose/config.py
+++ b/nose/config.py
@@ -636,8 +636,8 @@ class NoOptions(object):
 def user_config_files():
     """Return path to any existing user config files
     """
-    return filter(os.path.exists,
-                  map(os.path.expanduser, config_files))
+    return list(filter(os.path.exists,
+                       map(os.path.expanduser, config_files)))
 
 
 def all_config_files():

--- a/nose/core.py
+++ b/nose/core.py
@@ -224,32 +224,26 @@ class TestProgram(unittest.TestProgram):
         v = self.config.verbosity
         self.config.plugins.sort()
         for p in self.config.plugins:
-            print
-            "Plugin %s" % p.name
+            print("Plugin %s" % p.name)
             if v >= 2:
-                print
-                "  score: %s" % p.score
-                print
-                '\n'.join(textwrap.wrap(p.help().strip(),
-                                        initial_indent='  ',
-                                        subsequent_indent='  '))
+                print("  score: %s" % p.score)
+                print('\n'.join(textwrap.wrap(p.help().strip(),
+                                              initial_indent='  ',
+                                              subsequent_indent='  ')))
                 if v >= 3:
                     parser = DummyParser()
                     p.addOptions(parser)
                     if len(parser.options):
-                        print
-                        print
-                        "  Options:"
+                        print()
+                        print("  Options:")
                         for opts, help in parser.options:
-                            print
-                            '  %s' % (', '.join(opts))
+                            print('  %s' % (', '.join(opts)))
                             if help:
-                                print
-                                '\n'.join(
+                                print('\n'.join(
                                     textwrap.wrap(help.strip(),
                                                   initial_indent='    ',
-                                                  subsequent_indent='    '))
-                print
+                                                  subsequent_indent='    ')))
+                print()
 
     def usage(cls):
         import nose

--- a/nose/ext/dtcompat.py
+++ b/nose/ext/dtcompat.py
@@ -9,7 +9,7 @@
 #
 # Modified for inclusion in nose to provide support for DocFileTest
 #
-# - all doctests removed from module (they fail under 2.3 and 2.5) 
+# - all doctests removed from module (they fail under 2.3 and 2.5)
 # - now handles the $py.class extension when ran under Jython
 
 r"""Module doctest -- a framework for running examples in docstrings.
@@ -905,8 +905,7 @@ class DocTestFinder:
         add them to `tests`.
         """
         if self._verbose:
-            print
-            'Finding tests in %s' % name
+            print('Finding tests in %s' % name)
 
         # If we've already processed this object, then ignore it.
         if id(obj) in seen:

--- a/nose/failure.py
+++ b/nose/failure.py
@@ -15,7 +15,7 @@ class Failure(unittest.TestCase):
     A Failure case is placed in a test suite to indicate the presence of a
     test that could not be loaded or executed. A common example is a test
     module that fails to import.
-    
+
     """
     __test__ = False  # do not collect
 
@@ -37,7 +37,7 @@ class Failure(unittest.TestCase):
     def runTest(self):
         if self.tb is not None:
             if is_base_exception(self.exc_val):
-                raise self.exc_val(None).with_traceback(self.tb)
+                raise self.exc_class(None).with_traceback(self.tb)
             raise self.exc_class(self.exc_val).with_traceback(self.tb)
         else:
             raise self.exc_class(self.exc_val)

--- a/nose/loader.py
+++ b/nose/loader.py
@@ -330,10 +330,12 @@ class TestLoader(unittest.TestLoader):
                         test_classes.append(test)
                 elif isfunction(test) and self.selector.wantFunction(test):
                     test_funcs.append(test)
+
             test_classes = sort_list(test_classes, lambda x: x.__name__)
+            tests.extend(self.makeTest(t, parent=module) for t in test_classes)
+
             test_funcs = sort_list(test_funcs, func_lineno)
-            tests = map(lambda t: self.makeTest(t, parent=module),
-                        test_classes + test_funcs)
+            tests.extend(self.makeTest(t, parent=module) for t in test_funcs)
 
         # Now, descend into packages
         # FIXME can or should this be lazy?

--- a/nose/loader.py
+++ b/nose/loader.py
@@ -276,8 +276,8 @@ class TestLoader(unittest.TestLoader):
         """
         # convert the unbound generator method
         # into a bound method so it can be called below
-        if hasattr(generator, 'im_class'):
-            cls = generator.im_class
+        if hasattr(generator, '__self__'):
+            cls = generator.__self__.__class__
         inst = cls()
         method = generator.__name__
         generator = getattr(inst, method)

--- a/nose/loader.py
+++ b/nose/loader.py
@@ -112,7 +112,7 @@ class TestLoader(unittest.TestLoader):
                 return False
             return sel.wantMethod(item)
 
-        cases = filter(wanted, dir(testCaseClass))
+        cases = list(filter(wanted, dir(testCaseClass)))
 
         # add runTest if nothing else picked
         if not cases and hasattr(testCaseClass, 'runTest'):
@@ -225,7 +225,7 @@ class TestLoader(unittest.TestLoader):
                 # Plugins can yield False to indicate that they were
                 # unable to load tests from a file, but it was not an
                 # error -- the file just had no tests to load.
-                tests = filter(None, tests)
+                tests = list(filter(None, tests))
                 return self.suiteClass(tests)
             else:
                 # Nothing was able to even try to load from this file

--- a/nose/plugins/attrib.py
+++ b/nose/plugins/attrib.py
@@ -125,7 +125,7 @@ def attr(*args, **kwargs):
 
 
 def get_method_attr(method, cls, attr_name, default=False):
-    """Look up an attribute on a method/ function. 
+    """Look up an attribute on a method/ function.
     If the attribute isn't found there, looking it up in the
     method's class, if any.
     """
@@ -140,7 +140,7 @@ def get_method_attr(method, cls, attr_name, default=False):
 
 class ContextHelper:
     """Object that can act as context dictionary for eval and looks up
-    names as attributes on a method/ function and its class. 
+    names as attributes on a method/ function and its class.
     """
 
     def __init__(self, method, cls):
@@ -283,7 +283,7 @@ class AttributeSelector(Plugin):
         """Accept the method if its attributes match.
         """
         try:
-            cls = method.im_class
+            cls = method.__self__.__class__
         except AttributeError:
             return False
         return self.validateAttrib(method, cls)

--- a/nose/plugins/plugintest.py
+++ b/nose/plugins/plugintest.py
@@ -330,7 +330,7 @@ def run(*arg, **kw):
             sys.stderr = stderr
             sys.stdout = stdout
     out = buffer.getvalue()
-    print
+    print()
     munge_nose_output_for_doctest(out)
 
 

--- a/nose/plugins/xunit.py
+++ b/nose/plugins/xunit.py
@@ -55,7 +55,7 @@ from xml.sax import saxutils
 
 from io import StringIO
 
-from numpy import unicode
+from numpy.core import unicode
 
 from nose.plugins.base import Plugin
 from nose.pyversion import force_unicode, format_exception

--- a/nose/proxy.py
+++ b/nose/proxy.py
@@ -92,12 +92,12 @@ class ResultProxy(object):
         return repr(self.result)
 
     def _prepareErr(self, err):
-        if not isinstance(err[1], Exception) and isinstance(err[0], type):
+        if not isinstance(err[1], BaseException) and isinstance(err[0], type):
             # Turn value back into an Exception (required in Python 3.x).
             # Plugins do all sorts of crazy things with exception values.
             # Convert it to a custom subclass of Exception with the same
             # name as the actual exception to make it print correctly.
-            value = type(err[0].__name__, (Exception,), {})(err[1])
+            value = type(err[0].__name__, (BaseException,), {})(err[1])
             err = (err[0], value, err[2])
         return err
 

--- a/nose/proxy.py
+++ b/nose/proxy.py
@@ -92,12 +92,12 @@ class ResultProxy(object):
         return repr(self.result)
 
     def _prepareErr(self, err):
-        if not isinstance(err[1], BaseException) and isinstance(err[0], type):
+        if not isinstance(err[1], Exception) and isinstance(err[0], type):
             # Turn value back into an Exception (required in Python 3.x).
             # Plugins do all sorts of crazy things with exception values.
             # Convert it to a custom subclass of Exception with the same
             # name as the actual exception to make it print correctly.
-            value = type(err[0].__name__, (BaseException,), {})(err[1])
+            value = type(err[0].__name__, (Exception,), {})(err[1])
             err = (err[0], value, err[2])
         return err
 

--- a/nose/pyversion.py
+++ b/nose/pyversion.py
@@ -78,8 +78,6 @@ class UnboundMethod:
         self.__dict__ = func.__dict__.copy()
         self._func = func
         self.__self__ = UnboundSelf(cls)
-        if sys.version_info < (3, 0):
-            self.im_class = cls
         self.__doc__ = getattr(func, '__doc__', None)
 
     def address(self):

--- a/nose/pyversion.py
+++ b/nose/pyversion.py
@@ -6,7 +6,7 @@ import os
 import sys
 import traceback
 
-from numpy import unicode
+from numpy.core import unicode
 
 import nose.util
 

--- a/nose/pyversion.py
+++ b/nose/pyversion.py
@@ -10,8 +10,8 @@ from numpy.core import unicode
 
 import nose.util
 
-__all__ = ['make_instancemethod', 'cmp_to_key', 'sort_list', 'ClassType',
-           'TypeType', 'UNICODE_STRINGS', 'unbound_method', 'ismethod',
+__all__ = ['make_instancemethod', 'cmp_to_key', 'sort_list',
+           'UNICODE_STRINGS', 'unbound_method', 'ismethod',
            'bytes_', 'is_base_exception', 'force_unicode', 'exc_to_unicode',
            'format_exception', 'isgenerator']
 
@@ -59,13 +59,6 @@ def cmp_to_key(mycmp):
 def sort_list(l, key, reverse=False):
     sorted_list = sorted(l, key=key, reverse=reverse)
     return sorted_list
-
-
-# In Python 3.x, all objects are "new style" objects descended from 'type', and
-# thus types.ClassType and types.TypeType don't exist anymore.  For
-# compatibility, we make sure they still work.
-ClassType = type
-TypeType = type
 
 
 # The following emulates the behavior (we need) of an 'unbound method' under

--- a/nose/suite.py
+++ b/nose/suite.py
@@ -436,9 +436,7 @@ class ContextSuiteFactory(object):
         # Methods include reference to module they are defined in, we
         # don't want that, instead want the module the class is in now
         # (classes are re-ancestored elsewhere).
-        if hasattr(context, 'im_class'):
-            context = context.im_class
-        elif hasattr(context, '__self__'):
+        if hasattr(context, '__self__'):
             context = context.__self__.__class__
         if hasattr(context, '__module__'):
             ancestors = context.__module__.split('.')

--- a/nose/util.py
+++ b/nose/util.py
@@ -12,12 +12,11 @@ import unittest
 
 from numpy.core import unicode
 
-from nose.pyversion import ClassType, TypeType, isgenerator
+from nose.pyversion import isgenerator
 
 log = logging.getLogger('nose')
 
 ident_re = re.compile(r'^[A-Za-z_][A-Za-z0-9_.]*$')
-class_types = (ClassType, TypeType)
 skip_pattern = r"(?:\.svn)|(?:[^.]+\.py[co])|(?:.*~)|(?:.*\$py\.class)|(?:__pycache__)"
 set = set
 
@@ -157,7 +156,7 @@ def isclass(obj):
     for objects that can't be subclasses of anything.
     """
     obj_type = type(obj)
-    return obj_type in class_types or issubclass(obj_type, type)
+    return obj_type is type or issubclass(obj_type, type)
 
 
 # backwards compat (issue #64)
@@ -398,7 +397,7 @@ def test_address(test):
         file = getattr(test, '__file__', None)
         module = getattr(test, '__name__', None)
         return src(file), module, call
-    if t == types.FunctionType or issubclass(t, type) or t == types.ClassType:
+    if t == types.FunctionType or t is type or issubclass(t, type):
         module = getattr(test, '__module__', None)
         if module is not None:
             m = sys.modules[module]
@@ -449,15 +448,16 @@ def try_run(obj, names):
             if type(obj) == types.ModuleType:
                 # py.test compatibility
                 if isinstance(func, types.FunctionType):
-                    args, varargs, varkw, defaults = \
-                        inspect.getfullargspec(func)
+                    spec = inspect.getfullargspec(func)
+                    args, varargs, varkw, defaults = spec[:4]
+
                 else:
                     # Not a function. If it's callable, call it anyway
                     if hasattr(func, '__call__') and not inspect.ismethod(func):
                         func = func.__call__
                     try:
-                        args, varargs, varkw, defaults = \
-                            inspect.getfullargspec(func)
+                        spec = inspect.getfullargspec(func)
+                        args, varargs, varkw, defaults = spec[:4]
                         args.pop(0)  # pop the self off
                     except TypeError:
                         raise TypeError("Attribute %s of %r is not a python "

--- a/nose/util.py
+++ b/nose/util.py
@@ -408,7 +408,7 @@ def test_address(test):
         call = getattr(test, '__name__', None)
         return src(file), module, call
     if t == types.MethodType:
-        cls_adr = test_address(test.im_class)
+        cls_adr = test_address(test.__self__.__class__)
         return (src(cls_adr[0]), cls_adr[1],
                 "%s.%s" % (cls_adr[2], test.__name__))
     # handle unittest.TestCase instances

--- a/nose/util.py
+++ b/nose/util.py
@@ -10,7 +10,7 @@ import sys
 import types
 import unittest
 
-from numpy import unicode
+from numpy.core import unicode
 
 from nose.pyversion import ClassType, TypeType, isgenerator
 

--- a/selftest.py
+++ b/selftest.py
@@ -27,6 +27,8 @@ import glob
 import os
 import sys
 
+import pkg_resources
+
 if __name__ == "__main__":
     this_dir = os.path.normpath(os.path.abspath(os.path.dirname(__file__)))
     lib_dirs = [this_dir]
@@ -42,21 +44,21 @@ if __name__ == "__main__":
         lib_dirs = glob.glob(os.path.join(this_dir, 'build', 'lib*'))
         test_dir = os.path.join(this_dir, 'build', 'tests')
         if not os.path.isdir(test_dir):
-            raise AssertionError(
+            raise Exception(
                 "Error: %s does not exist.  Use the setup.py 'build_tests' command to create it." % (
                     test_dir,))
-    try:
-        import pkg_resources
 
-        env = pkg_resources.Environment(search_path=lib_dirs)
-        distributions = env["nose"]
-        assert len(distributions) == 1, (
-            "Incorrect usage of selftest.py; please see DEVELOPERS.txt")
-        dist = distributions[0]
-        dist.activate()
-    except ImportError:
-        import pkg_resources
-        pass
+    env = pkg_resources.Environment(search_path=lib_dirs)
+
+    distributions = env["nose-py3"]
+    if not distributions:
+        raise Exception("No nose distibution has been built")
+    elif len(distributions) != 1:
+        raise Exception("More than one nose distribution found")
+
+    dist = distributions[0]
+    dist.activate()
+
     # Always make sure our chosen test dir is first on the path
     sys.path.insert(0, test_dir)
     import nose

--- a/unit_tests/mock.py
+++ b/unit_tests/mock.py
@@ -33,38 +33,32 @@ class ResultProxy(proxy.ResultProxy):
         self.called.append(('beforeTest', test))
 
     def startTest(self, test):
-        print
-        "proxy startTest"
+        print("proxy startTest")
         self.assertMyTest(test)
         self.called.append(('startTest', test))
 
     def stopTest(self, test):
-        print
-        "proxy stopTest"
+        print("proxy stopTest")
         self.assertMyTest(test)
         self.called.append(('stopTest', test))
 
     def addDeprecated(self, test, err):
-        print
-        "proxy addDeprecated"
+        print("proxy addDeprecated")
         self.assertMyTest(test)
         self.called.append(('addDeprecated', test, err))
 
     def addError(self, test, err):
-        print
-        "proxy addError"
+        print("proxy addError")
         self.assertMyTest(test)
         self.called.append(('addError', test, err))
 
     def addFailure(self, test, err):
-        print
-        "proxy addFailure"
+        print("proxy addFailure")
         self.assertMyTest(test)
         self.called.append(('addFailure', test, err))
 
     def addSkip(self, test, err):
-        print
-        "proxy addSkip"
+        print("proxy addSkip")
         self.assertMyTest(test)
         self.called.append(('addSkip', test, err))
 
@@ -109,7 +103,7 @@ class Bucket(object):
         self.__dict__['d'].update(kw)
 
     def __getattr__(self, attr):
-        if not self.__dict__.has_key('d'):
+        if 'd' not in self.__dict__
             return None
         return self.__dict__['d'].get(attr)
 

--- a/unit_tests/support/script.py
+++ b/unit_tests/support/script.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python
 
-print
-"FAIL"
+print("FAIL")

--- a/unit_tests/test_bug105.py
+++ b/unit_tests/test_bug105.py
@@ -12,8 +12,7 @@ class TestBug105(unittest.TestCase):
 
         l = TestLoader()
         testmod = l.loadTestsFromDir(where).next()
-        print
-        testmod
+        print(testmod)
         testmod.setUp()
 
         def fix(t):
@@ -23,8 +22,7 @@ class TestBug105(unittest.TestCase):
             return s
 
         tests = map(fix, testmod)
-        print
-        tests
+        print(tests)
         self.assertEqual(tests, ['tests.test_z', 'tests.test_a',
                                  'tests.test_dz', 'tests.test_mdz',
                                  'tests.test_b'])

--- a/unit_tests/test_capture_plugin.py
+++ b/unit_tests/test_capture_plugin.py
@@ -53,16 +53,14 @@ class TestCapturePlugin(unittest.TestCase):
     def test_captures_stdout(self):
         c = Capture()
         c.start()
-        print
-        "Hello"
+        print("Hello")
         c.end()
         self.assertEqual(c.buffer, "Hello\n")
 
     def test_captures_nonascii_stdout(self):
         c = Capture()
         c.start()
-        print
-        "test 日本"
+        print("test 日本")
         c.end()
         self.assertEqual(c.buffer, "test 日本\n")
 
@@ -74,15 +72,14 @@ class TestCapturePlugin(unittest.TestCase):
         c = Capture()
         c.start()
         try:
-            print
-            "Oh my!"
+            print("Oh my!")
             raise Exception("boom")
         except:
             err = sys.exc_info()
         formatted = c.formatError(d, err)
         ec, ev, tb = err
         (fec, fev, ftb) = formatted
-        # print fec, fev, ftb
+        # print(fec, fev, ftb)
 
         self.assertEqual(ec, fec)
         self.assertEqual(tb, ftb)
@@ -97,8 +94,7 @@ class TestCapturePlugin(unittest.TestCase):
         c = Capture()
         c.start()
         try:
-            print
-            "debug 日本"
+            print("debug 日本")
             raise AssertionError(u'response does not contain 名')
         except:
             err = sys.exc_info()

--- a/unit_tests/test_cases.py
+++ b/unit_tests/test_cases.py
@@ -178,18 +178,15 @@ class TestNoseTestWrapper(unittest.TestCase):
 
         class TC(unittest.TestCase):
             def setUp(self):
-                print
-                "TC setUp %s" % self
+                print("TC setUp %s" % self)
                 called.append('setUp')
 
             def runTest(self):
-                print
-                "TC runTest %s" % self
+                print("TC runTest %s" % self)
                 called.append('runTest')
 
             def tearDown(self):
-                print
-                "TC tearDown %s" % self
+                print("TC tearDown %s" % self)
                 called.append('tearDown')
 
         case = nose.case.Test(TC())

--- a/unit_tests/test_config_defaults.rst
+++ b/unit_tests/test_config_defaults.rst
@@ -1,6 +1,6 @@
     >>> from optparse import OptionParser
     >>> import os
-    >>> from cStringIO import StringIO
+    >>> from io import StringIO
 
     >>> import nose.config
 
@@ -12,7 +12,7 @@ configuration files.  The configuration lives in a single section
     ...                        "config_defaults")
 
     >>> def error(msg):
-    ...     print "error: %s" % msg
+    ...     print("error: %s" % msg)
 
     >>> def get_parser():
     ...     parser = OptionParser()
@@ -129,18 +129,18 @@ Missing config files don't deserve an error or warning
 (filename)
 
     >>> options, args = parse([], os.path.join(support, "nonexistent.cfg"))
-    >>> print options.__dict__
+    >>> print(options.__dict__)
     {'verbosity': 1}
 
 (filenames)
 
     >>> options, args = parse([], [os.path.join(support, "nonexistent.cfg")])
-    >>> print options.__dict__
+    >>> print(options.__dict__)
     {'verbosity': 1}
 
 
 The same goes for missing config file section ("nosetests")
 
     >>> options, args = parse([], StringIO("[spam]\nfoo=bar\n"))
-    >>> print options.__dict__
+    >>> print(options.__dict__)
     {'verbosity': 1}

--- a/unit_tests/test_core.py
+++ b/unit_tests/test_core.py
@@ -1,8 +1,10 @@
 import os
 import sys
 import unittest
-from cStringIO import StringIO
+
+from io import StringIO
 from optparse import OptionParser
+
 import nose.core
 from nose.config import Config, all_config_files
 
@@ -15,20 +17,16 @@ class NullLoader:
 class TestAPI_run(unittest.TestCase):
 
     def test_restore_stdout(self):
-        print
-        "AHOY"
+        print("AHOY")
         s = StringIO()
-        print
-        s
+        print(s)
         stdout = sys.stdout
         conf = Config(stream=s)
         # set_trace()
-        print
-        "About to run"
+        print("About to run")
         res = nose.core.run(
             testLoader=NullLoader(), argv=['test_run'], env={}, config=conf)
-        print
-        "Done running"
+        print("Done running")
         stdout_after = sys.stdout
         self.assertEqual(stdout, stdout_after)
 

--- a/unit_tests/test_deprecated_plugin.py
+++ b/unit_tests/test_deprecated_plugin.py
@@ -1,7 +1,7 @@
 import unittest
 from optparse import OptionParser
 
-from StringIO import StringIO
+from io import StringIO
 
 from nose.config import Config
 from nose.plugins.deprecated import Deprecated, DeprecatedTest

--- a/unit_tests/test_doctest_munging.rst
+++ b/unit_tests/test_doctest_munging.rst
@@ -28,13 +28,13 @@ an ellipsis.  Note the first line here is chosen not to be "Traceback
 the example should raise an exception!
 
     >>> from nose.plugins.plugintest import remove_stack_traces
-    >>> print remove_stack_traces("""\
+    >>> print(remove_stack_traces("""\
     ... Ceci n'est pas une traceback.
     ... Traceback (most recent call last):
     ...   File "/some/dir/foomodule.py", line 15, in runTest
     ...   File "/some/dir/spam.py", line 293, in who_knows_what
     ... AssertionError: something bad happened
-    ... """)
+    ... """))
     Ceci n'est pas une traceback.
     Traceback (most recent call last):
     ...
@@ -44,7 +44,7 @@ the example should raise an exception!
 Multiple tracebacks in an example are all replaced, as long as they're
 separated by blank lines.
 
-    >>> print remove_stack_traces("""\
+    >>> print(remove_stack_traces("""\
     ... Ceci n'est pas une traceback.
     ... Traceback (most recent call last):
     ...   File spam
@@ -53,7 +53,7 @@ separated by blank lines.
     ... Traceback (most recent call last):
     ...   File eggs
     ... AttributeError: spam
-    ... """)
+    ... """))
     Ceci n'est pas une traceback.
     Traceback (most recent call last):
     ...
@@ -70,7 +70,7 @@ traces, removes test timings from "Ran n test(s)" output, and strips
 trailing blank lines.
 
     >>> from nose.plugins.plugintest import munge_nose_output_for_doctest
-    >>> print munge_nose_output_for_doctest("""\
+    >>> print(munge_nose_output_for_doctest("""\
     ... runTest (foomodule.PassingTest) ... ok
     ... runTest (foomodule.FailingTest) ... FAIL
     ...
@@ -88,7 +88,7 @@ trailing blank lines.
     ... FAILED (failures=1)
     ...
     ...
-    ... """)
+    ... """))
     runTest (foomodule.PassingTest) ... ok
     runTest (foomodule.FailingTest) ... FAIL
     <BLANKLINE>

--- a/unit_tests/test_id_plugin.py
+++ b/unit_tests/test_id_plugin.py
@@ -14,8 +14,7 @@ class TestTestIdPlugin(unittest.TestCase):
         opt = mock.Bucket()
         opt.testIdFile = '.noseids'
         tid.configure(opt, c)
-        print
-        tid.idfile
+        print(tid.idfile)
         assert tid.idfile.startswith(c.workingDir), \
             "%s is not under %s" % (tid.idfile, c.workingDir)
 

--- a/unit_tests/test_inspector.py
+++ b/unit_tests/test_inspector.py
@@ -3,10 +3,7 @@ import textwrap
 import tokenize
 import unittest
 
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from StringIO import StringIO
+from io import StringIO
 
 from nose.inspector import inspect_traceback, Expander, tbsource
 
@@ -21,7 +18,7 @@ class TestExpander(unittest.TestCase):
 
         for tok in tokenize.generate_tokens(src.readline):
             exp(*tok)
-        # print "'%s'" % exp.expanded_source
+        # print("'%s'" % exp.expanded_source)
         self.assertEqual(exp.expanded_source.strip(), '2 > 2')
 
     def test_inspect_traceback_continued(self):
@@ -33,7 +30,7 @@ class TestExpander(unittest.TestCase):
         except AssertionError:
             et, ev, tb = sys.exc_info()
             out = inspect_traceback(tb)
-            # print "'%s'" % out.strip()
+            # print("'%s'" % out.strip())
             self.assertEqual(out.strip(),
                              '>>  assert 6 < 1, \\\n        '
                              '"This is a multline expression"')
@@ -51,8 +48,7 @@ class TestExpander(unittest.TestCase):
     def test_get_tb_source_func(self):
         # func frame
         def check_even(n):
-            print
-            n
+            print(n)
             assert n % 2 == 0
 
         try:
@@ -61,10 +57,7 @@ class TestExpander(unittest.TestCase):
             et, ev, tb = sys.exc_info()
             lines, lineno = tbsource(tb)
             out = textwrap.dedent(''.join(lines))
-            if sys.version_info < (3,):
-                first_line = '    print n\n'
-            else:
-                first_line = '    print(n)\n'
+            first_line = '    print(n)\n'
             self.assertEqual(out,
                              first_line +
                              '    assert n % 2 == 0\n'
@@ -88,7 +81,7 @@ class TestExpander(unittest.TestCase):
         except AssertionError:
             et, ev, tb = sys.exc_info()
             out = inspect_traceback(tb)
-            # print "'%s'" % out.strip()
+            # print("'%s'" % out.strip())
             self.assertEqual(out.strip(),
                              ">>  assert defred('fred') == 'barney', "
                              '"Fred - fred != barney?"')
@@ -106,7 +99,7 @@ class TestExpander(unittest.TestCase):
         except AssertionError:
             et, ev, tb = sys.exc_info()
             out = inspect_traceback(tb)
-            # print "'%s'" % out.strip()
+            # print("'%s'" % out.strip())
             self.assertEqual(out.strip(),
                              ">>  assert defred('fred') == 'barney', "
                              '\\\n        "Fred - fred != barney?"')
@@ -115,8 +108,7 @@ class TestExpander(unittest.TestCase):
 
         def check_even(n, nn):
             assert S['setup']
-            print
-            n, nn
+            print(n, nn)
             assert n % 2 == 0 or nn % 2 == 0
 
         try:
@@ -124,12 +116,8 @@ class TestExpander(unittest.TestCase):
         except AssertionError:
             et, ev, tb = sys.exc_info()
             out = inspect_traceback(tb)
-            print
-            "'%s'" % out.strip()
-            if sys.version_info < (3,):
-                print_line = "    print 1, 3\n"
-            else:
-                print_line = "    print(1, 3)\n"
+            print("'%s'" % out.strip())
+            print_line = "    print(1, 3)\n"
             self.assertEqual(out.strip(),
                              "assert {'setup': 1}['setup']\n" +
                              print_line +
@@ -146,8 +134,7 @@ class TestExpander(unittest.TestCase):
         except AssertionError:
             et, ev, tb = sys.exc_info()
             out = inspect_traceback(tb)
-            print
-            "'%s'" % out.strip()
+            print("'%s'" % out.strip())
             self.assertEqual(out.strip(),
                              "2 = 2\n"
                              ">>  assert 2 == 4")

--- a/unit_tests/test_issue135.py
+++ b/unit_tests/test_issue135.py
@@ -5,10 +5,7 @@ import unittest
 
 from nose import main
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import BytesIO as StringIO
+from io import StringIO
 
 support = os.path.join(os.path.dirname(__file__), 'support')
 

--- a/unit_tests/test_issue_100.rst
+++ b/unit_tests/test_issue_100.rst
@@ -9,4 +9,4 @@ for a case defined in a doctest.
     ...         pass
     >>> test = nose.case.Test(SimpleTest())
     >>> test.address()
-    (None, '__builtin__', 'SimpleTest.runTest')
+    (None, 'builtins', 'SimpleTest.runTest')

--- a/unit_tests/test_issue_227.py
+++ b/unit_tests/test_issue_227.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 import sys
 
 from nose.plugins.skip import SkipTest
@@ -10,5 +9,4 @@ def setup():
 
 
 def test_unicode():
-    print
-    u'b\u00f6y'
+    print(u'b\u00f6y')

--- a/unit_tests/test_ls_tree.rst
+++ b/unit_tests/test_ls_tree.rst
@@ -1,15 +1,11 @@
     >>> import os
     >>> import tempfile
     >>> import shutil
-
     >>> from nose.util import ls_tree
-
     >>> dir_path = tempfile.mkdtemp()
-
     >>> def create_file(filename):
-    ...     fd = os.open(filename, os.O_WRONLY|os.O_CREAT, 0666)
+    ...     fd = os.open(filename, os.O_WRONLY|os.O_CREAT, 0o666)
     ...     os.close(fd)
-
     >>> os.mkdir(os.path.join(dir_path, "top"))
     >>> os.mkdir(os.path.join(dir_path, "top/dir"))
     >>> os.mkdir(os.path.join(dir_path, "top/dir2"))
@@ -32,7 +28,7 @@
     Note that files matching skip_pattern (by default SVN files,
     backup files and compiled Python files) are ignored
 
-    >>> print ls_tree(os.path.join(dir_path, "top"))
+    >>> print(ls_tree(os.path.join(dir_path, "top")))
     |-- file
     |-- file2
     |-- .notsvn

--- a/unit_tests/test_pdb_plugin.py
+++ b/unit_tests/test_pdb_plugin.py
@@ -2,7 +2,7 @@ import sys
 import unittest
 from optparse import OptionParser
 
-from StringIO import StringIO
+from io import StringIO
 
 from nose.config import Config
 from nose.plugins import debug

--- a/unit_tests/test_plugins.py
+++ b/unit_tests/test_plugins.py
@@ -52,7 +52,7 @@ class TestBuiltinPlugins(unittest.TestCase):
 
         plug.add_options(parser)
         o, d = parser.opts[0]
-        # print d
+        # print(d)
         assert o[0] == '--with-p'
         assert d['action'] == 'store_true'
         assert not d['default']
@@ -99,20 +99,16 @@ class TestDoctestPlugin(unittest.TestCase):
         dtp.add_options(parser, env)
         options, args = parser.parse_args(argv)
 
-        print
-        options
-        print
-        args
+        # print(options)
+        # print(args)
         self.assertEqual(options.doctestExtension, ['ext', 'txt'])
 
         env = {}
         parser = OptionParser()
         dtp.add_options(parser, env)
         options, args = parser.parse_args(argv)
-        print
-        options
-        print
-        args
+        # print(options)
+        # print(args)
         self.assertEqual(options.doctestExtension, ['txt'])
 
     def test_want_file(self):
@@ -175,15 +171,11 @@ class TestDoctestPlugin(unittest.TestCase):
         plug.configure(opt, conf)
         suite = plug.loadTestsFromModule(foo.bar.buz)
         for test in suite:
-            print
-            test.address()
-            file, mod, call = test.address()
+            # print(test.address(), file, mod, call = test.address())
             self.assertEqual(mod, 'foo.bar.buz')
             self.assertEqual(call, None)
             for case in test:
-                print
-                case.address()
-                file, mod, call = case.address()
+                # print(case.address(),file, mod, call = case.address())
                 self.assertEqual(mod, 'foo.bar.buz')
                 self.assertEqual(call, 'afunc')
 
@@ -204,7 +196,7 @@ class TestDoctestPlugin(unittest.TestCase):
             assert test.address(), "Test %s has no address"
 
     def test_collect_no_collect(self):
-        # bug http://nose.python-hosting.com/ticket/55 
+        # bug http://nose.python-hosting.com/ticket/55
         # we got "iteration over non-sequence" when no files match
         here = os.path.abspath(os.path.dirname(__file__))
         support = os.path.join(here, 'support')
@@ -350,9 +342,7 @@ class TestAttribPlugin(unittest.TestCase):
         # OR
         opt, args = parser.parse_args(['test', '-a', 'tags=a',
                                        '-a', 'tags=b'])
-        print
-        opt
-        plug.configure(opt, cnf)
+        # print(opt, plug.configure(opt, cnf))
 
         assert plug.wantFunction(f1) is None
         assert plug.wantFunction(f2) is None
@@ -361,9 +351,7 @@ class TestAttribPlugin(unittest.TestCase):
 
         # AND
         opt, args = parser.parse_args(['test', '-a', 'tags=a,tags=b'])
-        print
-        opt
-        plug.configure(opt, cnf)
+        # print(opt, plug.configure(opt, cnf))
 
         assert plug.wantFunction(f1) is None
         assert not plug.wantFunction(f2)

--- a/unit_tests/test_result_proxy.py
+++ b/unit_tests/test_result_proxy.py
@@ -84,10 +84,8 @@ class TestResultProxy(unittest.TestCase):
         class TC(unittest.TestCase):
             def run(self, result):
                 unittest.TestCase.run(self, result)
-                print
-                "errors", result.errors
-                print
-                "failures", result.failures
+                print("errors", result.errors)
+                print("failures", result.failures)
 
             def runTest(self):
                 pass
@@ -117,13 +115,11 @@ class TestResultProxy(unittest.TestCase):
 
         class TC(unittest.TestCase):
             def test_error(self):
-                print
-                "So long"
+                print("So long")
                 raise TypeError("oops")
 
             def test_fail(self):
-                print
-                "Hello"
+                print("Hello")
                 self.fail()
 
             def test(self):

--- a/unit_tests/test_skip_plugin.py
+++ b/unit_tests/test_skip_plugin.py
@@ -1,7 +1,7 @@
 import unittest
 from optparse import OptionParser
 
-from StringIO import StringIO
+from io import StringIO
 
 from nose.config import Config
 from nose.plugins.skip import Skip, SkipTest
@@ -86,8 +86,7 @@ class TestSkipPlugin(unittest.TestCase):
 
         res.printErrors()
         out = stream.getvalue()
-        print
-        out
+        print(out)
         assert out
         assert out.strip() == "S"
         assert res.wasSuccessful()
@@ -108,8 +107,7 @@ class TestSkipPlugin(unittest.TestCase):
 
         res.printErrors()
         out = stream.getvalue()
-        print
-        out
+        print(out)
         assert out
 
         assert ' ... SKIP' in out

--- a/unit_tests/test_suite.py
+++ b/unit_tests/test_suite.py
@@ -50,12 +50,10 @@ class TestLazySuite(unittest.TestCase):
         lazytests = []
         nonlazytests = []
         for t in lazy:
-            print
-            "lazy %s" % t
+            print("lazy %s" % t)
             lazytests.append(t)
         for t in nonlazy:
-            print
-            "nonlazy %s" % t
+            print("nonlazy %s" % t)
             nonlazytests.append(t)
         slazy = map(str, lazytests)
         snonlazy = map(str, nonlazytests)
@@ -80,8 +78,7 @@ class TestLazySuite(unittest.TestCase):
 
         count = 0
         for test in lazy:
-            print
-            test
+            print(test)
             assert test
             count += 1
         self.assertEqual(count, 2, "Expected 2 tests, got %s" % count)

--- a/unit_tests/test_tools.py
+++ b/unit_tests/test_tools.py
@@ -1,8 +1,7 @@
 import time
+import unittest
 
 from nose.tools import *
-
-compat_24 = sys.version_info >= (2, 4)
 
 
 class TestTools(unittest.TestCase):
@@ -167,14 +166,11 @@ class TestTools(unittest.TestCase):
         import nose.tools
         tc_asserts = [at for at in dir(nose.tools)
                       if at.startswith('assert_')]
-        print
-        tc_asserts
+        print(tc_asserts)
 
         # FIXME: not sure which of these are in all supported
         # versions of python
         assert 'assert_raises' in tc_asserts
-        if compat_24:
-            assert 'assert_true' in tc_asserts
 
     def test_multiple_with_setup(self):
         from nose.tools import with_setup


### PR DESCRIPTION
* Modifies loader code which formerly returned a map instance to instead return a list.
* Removes out-of-date references to Python2's `im_class` in favor of Python3's `__self__.__class__`
* Fixes missing `numpy.unicode` references, replaced with `numpy.core.unicode`
* Starts the process of converting unit_tests into something that works under Python3

Fixes #2 
