### PR TITLE
Removal of imp import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.idea/nose-py3.iml
+.idea/misc.xml

--- a/TODO_0_9
+++ b/TODO_0_9
@@ -21,7 +21,7 @@ Refactor
  
 Output capture handling
 -----------------------
- - Monkeypatch in a new _TextTestResult instead of all of the current chicanery
+ - Monkeypatch in a new TextTestResult instead of all of the current chicanery
 
  
 Assert introspection

--- a/distribute_setup.py
+++ b/distribute_setup.py
@@ -14,6 +14,7 @@ the appropriate options to ``use_setuptools()``.
 This file can also be run as a script to install or upgrade setuptools.
 """
 import fnmatch
+import importlib.metadata
 import optparse
 import os
 import shutil
@@ -21,7 +22,7 @@ import sys
 import tarfile
 import tempfile
 import time
-from distutils import log
+import logging
 from filecmp import cmp
 
 try:
@@ -71,7 +72,7 @@ Description: xxx
 def _install(tarball, install_args=()):
     # extracting the tarball
     tmpdir = tempfile.mkdtemp()
-    log.warn('Extracting in %s', tmpdir)
+    logging.warning('Extracting in %s', tmpdir)
     old_wd = os.getcwd()
     try:
         os.chdir(tmpdir)
@@ -82,13 +83,13 @@ def _install(tarball, install_args=()):
         # going in the directory
         subdir = os.path.join(tmpdir, os.listdir(tmpdir)[0])
         os.chdir(subdir)
-        log.warn('Now working in %s', subdir)
+        logging.warning('Now working in %s', subdir)
 
         # installing
-        log.warn('Installing Distribute')
+        logging.warning('Installing Distribute')
         if not _python_cmd('setup.py', 'install', *install_args):
-            log.warn('Something went wrong during the installation.')
-            log.warn('See the error message above.')
+            logging.warning('Something went wrong during the installation.')
+            logging.warning('See the error message above.')
             # exitcode will be 2
             return 2
     finally:
@@ -99,7 +100,7 @@ def _install(tarball, install_args=()):
 def _build_egg(egg, tarball, to_dir):
     # extracting the tarball
     tmpdir = tempfile.mkdtemp()
-    log.warn('Extracting in %s', tmpdir)
+    logging.warning('Extracting in %s', tmpdir)
     old_wd = os.getcwd()
     try:
         os.chdir(tmpdir)
@@ -110,17 +111,17 @@ def _build_egg(egg, tarball, to_dir):
         # going in the directory
         subdir = os.path.join(tmpdir, os.listdir(tmpdir)[0])
         os.chdir(subdir)
-        log.warn('Now working in %s', subdir)
+        logging.warning('Now working in %s', subdir)
 
         # building an egg
-        log.warn('Building a Distribute egg in %s', to_dir)
+        logging.warning('Building a Distribute egg in %s', to_dir)
         _python_cmd('setup.py', '-q', 'bdist_egg', '--dist-dir', to_dir)
 
     finally:
         os.chdir(old_wd)
         shutil.rmtree(tmpdir)
     # returning the result
-    log.warn(egg)
+    logging.warning(egg)
     if not os.path.exists(egg):
         raise IOError('Could not build the egg.')
 
@@ -137,25 +138,35 @@ def _do_download(version, download_base, to_dir, download_delay):
     setuptools.bootstrap_install_from = egg
 
 
+# replacement for pkg_resources require
+def importlib_require(name, version):
+    try:
+        distribution = importlib.metadata.metadata(name)
+        installed_version = distribution['Version']
+        return installed_version >= version
+    except importlib.metadata.PackageNotFoundError:
+        return False
+
+
 def use_setuptools(version=DEFAULT_VERSION, download_base=DEFAULT_URL,
                    to_dir=os.curdir, download_delay=15, no_fake=True):
     # making sure we use the absolute path
     to_dir = os.path.abspath(to_dir)
-    was_imported = 'pkg_resources' in sys.modules or \
+    was_imported = 'importlib.metadata' in sys.modules or \
                    'setuptools' in sys.modules
     try:
         try:
-            import pkg_resources
-            if not hasattr(pkg_resources, '_distribute'):
+            import importlib.metadata
+            if not hasattr(importlib.metadata, '_distribute'):
                 if not no_fake:
                     _fake_setuptools()
                 raise ImportError
         except ImportError:
             return _do_download(version, download_base, to_dir, download_delay)
         try:
-            pkg_resources.require("distribute>=" + version)
+            importlib_require("distribute>=", version)
             return
-        except pkg_resources.VersionConflict:
+        except importlib_require:
             e = sys.exc_info()[1]
             if was_imported:
                 sys.stderr.write(
@@ -166,10 +177,10 @@ def use_setuptools(version=DEFAULT_VERSION, download_base=DEFAULT_URL,
                     "\n\n(Currently using %r)\n" % (version, e.args[0]))
                 sys.exit(2)
             else:
-                del pkg_resources, sys.modules['pkg_resources']  # reload ok
+                del importlib.metadata, sys.modules['importlib.metadata']  # reload ok
                 return _do_download(version, download_base, to_dir,
                                     download_delay)
-        except pkg_resources.DistributionNotFound:
+        except importlib_require:
             return _do_download(version, download_base, to_dir,
                                 download_delay)
     finally:
@@ -196,7 +207,7 @@ def download_setuptools(version=DEFAULT_VERSION, download_base=DEFAULT_URL,
     src = dst = None
     if not os.path.exists(saveto):  # Avoid repeated downloads
         try:
-            log.warn("Downloading %s", url)
+            logging.warning("Downloading %s", url)
             src = urlopen(url)
             # Read/write all in one block, so we don't create a corrupt file
             # if the download is interrupted.
@@ -244,9 +255,9 @@ def _patch_file(path, content):
     f.close()
     if existing_content == content:
         # already patched
-        log.warn('Already patched.')
+        logging.warning('Already patched.')
         return False
-    log.warn('Patching...')
+    logging.warning('Patching...')
     _rename_path(path)
     f = open(path, 'w')
     try:
@@ -268,14 +279,14 @@ def _same_content(path, content):
 
 def _rename_path(path):
     new_name = path + '.OLD.%s' % time.time()
-    log.warn('Renaming %s to %s', path, new_name)
+    logging.warning('Renaming %s to %s', path, new_name)
     os.rename(path, new_name)
     return new_name
 
 
 def _remove_flat_installation(placeholder):
     if not os.path.isdir(placeholder):
-        log.warn('Unkown installation at %s', placeholder)
+        logging.warning('Unkown installation at %s', placeholder)
         return False
     found = False
     for file in os.listdir(placeholder):
@@ -283,10 +294,10 @@ def _remove_flat_installation(placeholder):
             found = True
             break
     if not found:
-        log.warn('Could not locate setuptools*.egg-info')
+        logging.warning('Could not locate setuptools*.egg-info')
         return
 
-    log.warn('Moving elements out of the way...')
+    logging.warning('Moving elements out of the way...')
     pkg_info = os.path.join(placeholder, file)
     if os.path.isdir(pkg_info):
         patched = _patch_egg_dir(pkg_info)
@@ -294,15 +305,15 @@ def _remove_flat_installation(placeholder):
         patched = _patch_file(pkg_info, SETUPTOOLS_PKG_INFO)
 
     if not patched:
-        log.warn('%s already patched.', pkg_info)
+        logging.warning('%s already patched.', pkg_info)
         return False
     # now let's move the files out of the way
-    for element in ('setuptools', 'pkg_resources.py', 'site.py'):
+    for element in ('setuptools', 'site.py'):
         element = os.path.join(placeholder, element)
         if os.path.exists(element):
             _rename_path(element)
         else:
-            log.warn('Could not find the %s element of the '
+            logging.warning('Could not find the %s element of the '
                      'Setuptools distribution', element)
     return True
 
@@ -311,28 +322,28 @@ _remove_flat_installation = _no_sandbox(_remove_flat_installation)
 
 
 def _after_install(dist):
-    log.warn('After install bootstrap.')
+    logging.warning('After install bootstrap.')
     placeholder = dist.get_command_obj('install').install_purelib
     _create_fake_setuptools_pkg_info(placeholder)
 
 
 def _create_fake_setuptools_pkg_info(placeholder):
     if not placeholder or not os.path.exists(placeholder):
-        log.warn('Could not find the install location')
+        logging.warning('Could not find the install location')
         return
     pyver = '%s.%s' % (sys.version_info[0], sys.version_info[1])
     setuptools_file = 'setuptools-%s-py%s.egg-info' % \
                       (SETUPTOOLS_FAKED_VERSION, pyver)
     pkg_info = os.path.join(placeholder, setuptools_file)
     if os.path.exists(pkg_info):
-        log.warn('%s already exists', pkg_info)
+        logging.warning('%s already exists', pkg_info)
         return
 
-    log.warn('Creating %s', pkg_info)
+    logging.warning('Creating %s', pkg_info)
     try:
         f = open(pkg_info, 'w')
     except EnvironmentError:
-        log.warn("Don't have permissions to write %s, skipping", pkg_info)
+        logging.warning("Don't have permissions to write %s, skipping", pkg_info)
         return
     try:
         f.write(SETUPTOOLS_PKG_INFO)
@@ -340,7 +351,7 @@ def _create_fake_setuptools_pkg_info(placeholder):
         f.close()
 
     pth_file = os.path.join(placeholder, 'setuptools.pth')
-    log.warn('Creating %s', pth_file)
+    logging.warning('Creating %s', pth_file)
     f = open(pth_file, 'w')
     try:
         f.write(os.path.join(os.curdir, setuptools_file))
@@ -358,7 +369,7 @@ def _patch_egg_dir(path):
     pkg_info = os.path.join(path, 'EGG-INFO', 'PKG-INFO')
     if os.path.exists(pkg_info):
         if _same_content(pkg_info, SETUPTOOLS_PKG_INFO):
-            log.warn('%s already patched.', pkg_info)
+            logging.warning('%s already patched.', pkg_info)
             return False
     _rename_path(path)
     os.mkdir(path)
@@ -376,7 +387,7 @@ _patch_egg_dir = _no_sandbox(_patch_egg_dir)
 
 
 def _before_install():
-    log.warn('Before install bootstrap.')
+    logging.warning('Before install bootstrap.')
     _fake_setuptools()
 
 
@@ -399,62 +410,70 @@ def _under_prefix(location):
 
 
 def _fake_setuptools():
-    log.warn('Scanning installed packages')
+    logging.warning('Scanning installed packages')
     try:
-        import pkg_resources
+        import importlib.metadata
     except ImportError:
         # we're cool
-        log.warn('Setuptools or Distribute does not seem to be installed.')
+        logging.warning('Setuptools or Distribute does not seem to be installed.')
         return
-    ws = pkg_resources.working_set
+    ws = list(importlib.metadata.distributions())
     try:
-        setuptools_dist = ws.find(
-            pkg_resources.Requirement.parse('setuptools', replacement=False)
-        )
-    except TypeError:
-        # old distribute API
-        setuptools_dist = ws.find(
-            pkg_resources.Requirement.parse('setuptools')
-        )
+        setuptools_dist = importlib.metadata.distribution('setuptools')
+    except importlib.metadata.PackageNotFoundError:
+        setuptools_dist = None
+        try:
+            setuptools_dist = importlib.metadata.distribution('setuptools')
+        except importlib.metadata.PackageNotFoundError:
+            setuptools_dist = None
+
+        if setuptools_dist is None:
+            for distribution in importlib.metadata.distributions():
+                metadata = distribution.metadata
+                if metadata.get('Name') == 'setuptools':
+                    setuptools_dist = distribution
+                    break
+
+        return setuptools_dist
 
     if setuptools_dist is None:
-        log.warn('No setuptools distribution found')
+        logging.warning('No setuptools distribution found')
         return
     # detecting if it was already faked
     setuptools_location = setuptools_dist.location
-    log.warn('Setuptools installation detected at %s', setuptools_location)
+    logging.warning('Setuptools installation detected at %s', setuptools_location)
 
     # if --root or --preix was provided, and if
     # setuptools is not located in them, we don't patch it
     if not _under_prefix(setuptools_location):
-        log.warn('Not patching, --root or --prefix is installing Distribute'
+        logging.warning('Not patching, --root or --prefix is installing Distribute'
                  ' in another location')
         return
 
     # let's see if its an egg
     if not setuptools_location.endswith('.egg'):
-        log.warn('Non-egg installation')
+        logging.warning('Non-egg installation')
         res = _remove_flat_installation(setuptools_location)
         if not res:
             return
     else:
-        log.warn('Egg installation')
+        logging.warning('Egg installation')
         pkg_info = os.path.join(setuptools_location, 'EGG-INFO', 'PKG-INFO')
         if (os.path.exists(pkg_info) and
                 _same_content(pkg_info, SETUPTOOLS_PKG_INFO)):
-            log.warn('Already patched.')
+            logging.warning('Already patched.')
             return
-        log.warn('Patching...')
+        logging.warning('Patching...')
         # let's create a fake egg replacing setuptools one
         res = _patch_egg_dir(setuptools_location)
         if not res:
             return
-    log.warn('Patching complete.')
+    logging.warning('Patching complete.')
     _relaunch()
 
 
 def _relaunch():
-    log.warn('Relaunching...')
+    logging.warning('Relaunching...')
     # we have to relaunch the process
     # pip marker to avoid a relaunch bug
     _cmd1 = ['-c', 'install', '--single-version-externally-managed']
@@ -520,7 +539,7 @@ def _build_install_args(options):
     install_args = []
     if options.user_install:
         if sys.version_info < (2, 6):
-            log.warn("--user requires Python 2.6 or later")
+            logging.warning("--user requires Python 2.6 or later")
             raise SystemExit(1)
         install_args.append('--user')
     return install_args

--- a/functional_tests/test_buggy_generators.py
+++ b/functional_tests/test_buggy_generators.py
@@ -3,7 +3,7 @@ import unittest
 from io import StringIO
 from nose.core import TestProgram
 from nose.config import Config
-from nose.result import _TextTestResult
+from nose.result import TextTestResult
 
 here = os.path.dirname(__file__)
 support = os.path.join(here, 'support')
@@ -11,7 +11,7 @@ support = os.path.join(here, 'support')
 
 class TestRunner(unittest.TextTestRunner):
     def _makeResult(self):
-        self.result = _TextTestResult(
+        self.result = TextTestResult(
             self.stream, self.descriptions, self.verbosity)
         return self.result
 

--- a/functional_tests/test_collector.py
+++ b/functional_tests/test_collector.py
@@ -4,7 +4,7 @@ import warnings
 
 from io import StringIO
 
-from nose.result import _TextTestResult
+from nose.result import TextTestResult
 
 here = os.path.dirname(__file__)
 support = os.path.join(here, 'support')
@@ -12,7 +12,7 @@ support = os.path.join(here, 'support')
 
 class TestRunner(unittest.TextTestRunner):
     def _makeResult(self):
-        self.result = _TextTestResult(
+        self.result = TextTestResult(
             self.stream, self.descriptions, self.verbosity)
         return self.result
 

--- a/functional_tests/test_loader.py
+++ b/functional_tests/test_loader.py
@@ -11,7 +11,7 @@ from nose.config import Config
 from nose.plugins.allmodules import AllModules
 from nose.plugins.manager import PluginManager
 from nose.plugins.skip import Skip
-from nose.result import _TextTestResult
+from nose.result import TextTestResult
 
 try:
     # 2.7+
@@ -245,7 +245,7 @@ class TestNoseTestLoader(unittest.TestCase):
 
     def test_fixture_context_multiple_names_some_common_ancestors(self):
         stream = _WritelnDecorator(StringIO())
-        res = _TextTestResult(stream, 0, 2)
+        res = TextTestResult(stream, 0, 2)
         wd = os.path.join(support, 'ltfn')
         l = loader.TestLoader(workingDir=wd)
         suite = l.loadTestsFromNames(
@@ -279,7 +279,7 @@ class TestNoseTestLoader(unittest.TestCase):
 
     def test_fixture_context_multiple_names_no_common_ancestors(self):
         stream = _WritelnDecorator(StringIO())
-        res = _TextTestResult(stream, 0, 2)
+        res = TextTestResult(stream, 0, 2)
         wd = os.path.join(support, 'ltfn')
         l = loader.TestLoader(workingDir=wd)
         suite = l.loadTestsFromNames(
@@ -361,7 +361,7 @@ class TestNoseTestLoader(unittest.TestCase):
         l = loader.TestLoader(workingDir=ctx)
         suite = l.loadTestsFromName('no_such_module.py')
 
-        res = _TextTestResult(
+        res = TextTestResult(
             stream=_WritelnDecorator(sys.stdout),
             descriptions=0, verbosity=1)
         suite(res)
@@ -379,7 +379,7 @@ class TestNoseTestLoader(unittest.TestCase):
         l = loader.TestLoader(workingDir=ctx)
         suite = l.loadTestsFromName('no_such_module')
 
-        res = _TextTestResult(
+        res = TextTestResult(
             stream=_WritelnDecorator(sys.stdout),
             descriptions=0, verbosity=1)
         suite(res)
@@ -397,7 +397,7 @@ class TestNoseTestLoader(unittest.TestCase):
         l = loader.TestLoader(workingDir=ctx)
         suite = l.loadTestsFromName('fred!')
 
-        res = _TextTestResult(
+        res = TextTestResult(
             stream=_WritelnDecorator(sys.stdout),
             descriptions=0, verbosity=1)
         suite(res)
@@ -416,7 +416,7 @@ class TestNoseTestLoader(unittest.TestCase):
         gen = os.path.join(support, 'gen')
         l = loader.TestLoader(workingDir=gen)
         suite = l.loadTestsFromName('test')
-        res = _TextTestResult(
+        res = TextTestResult(
             stream=_WritelnDecorator(sys.stdout),
             descriptions=0, verbosity=1)
         suite(res)
@@ -429,7 +429,7 @@ class TestNoseTestLoader(unittest.TestCase):
         wdir = os.path.join(support, 'issue269')
         l = loader.TestLoader(workingDir=wdir)
         suite = l.loadTestsFromName('test_bad_class')
-        res = _TextTestResult(
+        res = TextTestResult(
             stream=_WritelnDecorator(sys.stdout),
             descriptions=0, verbosity=1)
         suite(res)

--- a/functional_tests/test_program.py
+++ b/functional_tests/test_program.py
@@ -7,7 +7,7 @@ from nose import SkipTest
 from nose.config import Config
 from nose.core import TestProgram
 from nose.plugins.manager import DefaultPluginManager
-from nose.result import _TextTestResult
+from nose.result import TextTestResult
 
 here = os.path.dirname(__file__)
 support = os.path.join(here, 'support')
@@ -15,7 +15,7 @@ support = os.path.join(here, 'support')
 
 class TestRunner(unittest.TextTestRunner):
     def _makeResult(self):
-        self.result = _TextTestResult(
+        self.result = TextTestResult(
             self.stream, self.descriptions, self.verbosity)
         return self.result
 

--- a/nose/__init__.py
+++ b/nose/__init__.py
@@ -4,7 +4,7 @@ from nose.plugins.skip import SkipTest
 from nose.tools import with_setup
 
 __author__ = 'Adam Bilbrough'
-__versioninfo__ = (1, 6, 3)
+__versioninfo__ = (1, 6, 4)
 __version__ = '.'.join(map(str, __versioninfo__))
 
 __all__ = [

--- a/nose/commands.py
+++ b/nose/commands.py
@@ -113,31 +113,21 @@ else:
         def run(self):
             """ensure tests are capable of being run, then
             run nose.main with a reconstructed argument list"""
-            if getattr(self.distribution, 'use_2to3', False):
-                # If we run 2to3 we can not do this inplace:
+            # Ensure metadata is up-to-date
+            build_py = self.get_finalized_command('build_py')
+            build_py.inplace = 0
+            build_py.run()
+            bpy_cmd = self.get_finalized_command("build_py")
+            build_path = bpy_cmd.build_lib
 
-                # Ensure metadata is up-to-date
-                build_py = self.get_finalized_command('build_py')
-                build_py.inplace = 0
-                build_py.run()
-                bpy_cmd = self.get_finalized_command("build_py")
-                build_path = bpy_cmd.build_lib
+            # Build extensions
+            egg_info = self.get_finalized_command('egg_info')
+            egg_info.egg_base = build_path
+            egg_info.run()
 
-                # Build extensions
-                egg_info = self.get_finalized_command('egg_info')
-                egg_info.egg_base = build_path
-                egg_info.run()
-
-                build_ext = self.get_finalized_command('build_ext')
-                build_ext.inplace = 0
-                build_ext.run()
-            else:
-                self.run_command('egg_info')
-
-                # Build extensions in-place
-                build_ext = self.get_finalized_command('build_ext')
-                build_ext.inplace = 1
-                build_ext.run()
+            build_ext = self.get_finalized_command('build_ext')
+            build_ext.inplace = 0
+            build_ext.run()
 
             if self.distribution.install_requires:
                 self.distribution.fetch_build_eggs(

--- a/nose/core.py
+++ b/nose/core.py
@@ -12,7 +12,7 @@ from nose.config import Config, all_config_files
 from nose.loader import defaultTestLoader
 from nose.plugins.manager import PluginManager, DefaultPluginManager, \
     RestrictedPluginManager
-from nose.result import TextTestResult
+from nose.result import TextTestResult, NoseTextTestResult
 from nose.suite import FinalizingSuiteWrapper
 from nose.util import isclass, tolist
 
@@ -37,10 +37,10 @@ class TextTestRunner(unittest.TextTestRunner):
         unittest.TextTestRunner.__init__(self, stream, descriptions, verbosity)
 
     def _makeResult(self):
-        return TextTestResult(self.stream,
-                              self.descriptions,
-                              self.verbosity,
-                              self.config)
+        return NoseTextTestResult(self.stream,
+                                  self.descriptions,
+                                  self.verbosity,
+                                  self.config)
 
     def run(self, test):
         """Overrides to provide plugin hooks and defer all output to

--- a/nose/importer.py
+++ b/nose/importer.py
@@ -7,11 +7,12 @@ the builtin importer.
 import logging
 import os
 import sys
-from imp import find_module, load_module, acquire_lock, release_lock
-
+from importlib.util import find_spec, spec_from_file_location, module_from_spec
+from threading import Lock
 from nose.config import Config
 
 log = logging.getLogger(__name__)
+_import_lock = Lock()
 
 try:
     _samefile = os.path.samefile
@@ -19,6 +20,41 @@ except AttributeError:
     def _samefile(src, dst):
         return (os.path.normcase(os.path.realpath(src)) ==
                 os.path.normcase(os.path.realpath(dst)))
+
+"""
+Below are the new standalone importlib variant functions
+to replace the deprecated and removed 'imp' import
+
+The names are kept the same for ease of use.
+"""
+
+
+def find_module(part, path=None):
+    spec = find_spec(part, path)
+    if spec is None:
+        raise ImportError(f"Error: The Module {part} is not found")
+
+    filename = spec.origin
+    desc = (".py", "U", 1)
+
+    fh = open(filename, 'r') if spec.origin else None
+
+    return fh, filename, desc
+
+
+def load_module(module_name, fh, filename, desc):
+    if fh:
+        fh.close()
+
+    spec = spec_from_file_location(module_name, filename)
+    if spec is None:
+        raise ImportError(f"Error: Can not load the module {module_name}")
+
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    sys.modules[module_name] = module
+
+    return module
 
 
 class Importer(object):
@@ -74,7 +110,7 @@ class Importer(object):
             else:
                 part_fqname = "%s.%s" % (part_fqname, part)
             try:
-                acquire_lock()
+                _import_lock.acquire()
                 log.debug("find module part %s (%s) in %s",
                           part, part_fqname, path)
                 fh, filename, desc = find_module(part, path)
@@ -96,7 +132,7 @@ class Importer(object):
             finally:
                 if fh:
                     fh.close()
-                release_lock()
+                _import_lock.release()
             if parent:
                 setattr(parent, part, mod)
             if hasattr(mod, '__path__'):

--- a/nose/plugins/manager.py
+++ b/nose/plugins/manager.py
@@ -396,7 +396,7 @@ class BuiltinPluginManager(PluginManager):
 
 
 try:
-    import pkg_resources
+    import importlib.metadata
 
 
     class DefaultPluginManager(BuiltinPluginManager, EntryPointPluginManager):

--- a/nose/plugins/manager.py
+++ b/nose/plugins/manager.py
@@ -59,9 +59,6 @@ from nose.failure import Failure
 from nose.plugins.base import IPluginInterface
 from nose.pyversion import sort_list
 
-import pickle
-from io import StringIO
-
 __all__ = ['DefaultPluginManager', 'PluginManager', 'EntryPointPluginManager',
            'BuiltinPluginManager', 'RestrictedPluginManager']
 
@@ -357,13 +354,13 @@ class EntryPointPluginManager(PluginManager):
     def loadPlugins(self):
         """Load plugins by iterating the `nose.plugins` entry point.
         """
-        from pkg_resources import iter_entry_points
+        from importlib.metadata import entry_points
         loaded = {}
         for entry_point, adapt in self.entry_points:
-            for ep in iter_entry_points(entry_point):
+            for ep in entry_points(group=entry_point):
                 if ep.name in loaded:
                     continue
-                loaded[ep.name] = True
+                loaded[ep.name] = ep.load()
                 log.debug('%s load plugin %s', self.__class__.__name__, ep)
                 try:
                     plugcls = ep.load()

--- a/nose/pyversion.py
+++ b/nose/pyversion.py
@@ -15,9 +15,6 @@ __all__ = ['make_instancemethod', 'cmp_to_key', 'sort_list',
            'bytes_', 'is_base_exception', 'force_unicode', 'exc_to_unicode',
            'format_exception', 'isgenerator']
 
-# In Python 3.x, all strings are unicode (the call to 'unicode()' in the 2.x
-# source will be replaced with 'str()' when running 2to3, so this test will
-# then become true)
 UNICODE_STRINGS = (type(unicode()) == type(str()))
 
 

--- a/nose/result.py
+++ b/nose/result.py
@@ -2,7 +2,7 @@
 Test Result
 -----------
 
-Provides a TextTestResult that extends unittest's _TextTestResult to
+Provides a TextTestResult that extends unittest's TextTestResult to
 provide support for error classes (such as the builtin skip and
 deprecated classes), and hooks for plugins to take over or extend
 reporting.
@@ -11,9 +11,9 @@ reporting.
 import logging
 
 try:
-    from unittest.runner import _TextTestResult
+    from unittest.runner import TextTestResult
 except ImportError:
-    from unittest import _TextTestResult
+    from unittest import TextTestResult
 from nose.config import Config
 from nose.util import isclass, ln as _ln  # backwards compat
 
@@ -28,7 +28,7 @@ def _exception_detail(exc):
         return '<unprintable %s object>' % type(exc).__name__
 
 
-class TextTestResult(_TextTestResult):
+class TextTestResult(TextTestResult):
     """Text test result that extends unittest's default test result
     support for a configurable set of errorClasses (eg, Skip,
     Deprecated, TODO) that extend the errors/failures/success triad.
@@ -42,7 +42,7 @@ class TextTestResult(_TextTestResult):
         if config is None:
             config = Config()
         self.config = config
-        _TextTestResult.__init__(self, stream, descriptions, verbosity)
+        TextTestResult.__init__(self, stream, descriptions, verbosity)
 
     def addSkip(self, test, reason):
         from nose.plugins.skip import SkipTest
@@ -96,7 +96,7 @@ class TextTestResult(_TextTestResult):
     def printErrors(self):
         """Overrides to print all errorClasses errors as well.
         """
-        _TextTestResult.printErrors(self)
+        TextTestResult.printErrors(self)
         for cls in self.errorClasses.keys():
             storage, label, isfail = self.errorClasses[cls]
             if isfail:
@@ -178,10 +178,10 @@ class TextTestResult(_TextTestResult):
         if isclass(err[0]) and issubclass(err[0], SkipTest):
             return str(err[1])
         try:
-            return _TextTestResult._exc_info_to_string(self, err, test)
+            return TextTestResult._exc_info_to_string(self, err, test)
         except TypeError:
             # 2.3: does not take test arg
-            return _TextTestResult._exc_info_to_string(self, err)
+            return TextTestResult._exc_info_to_string(self, err)
 
 
 def ln(*arg, **kw):

--- a/nose/result.py
+++ b/nose/result.py
@@ -28,7 +28,7 @@ def _exception_detail(exc):
         return '<unprintable %s object>' % type(exc).__name__
 
 
-class TextTestResult(TextTestResult):
+class NoseTextTestResult(TextTestResult):
     """Text test result that extends unittest's default test result
     support for a configurable set of errorClasses (eg, Skip,
     Deprecated, TODO) that extend the errors/failures/success triad.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ numpy
 coverage
 six
 sphinx
+setuptools
+logging

--- a/selftest.py
+++ b/selftest.py
@@ -27,7 +27,20 @@ import glob
 import os
 import sys
 
-import pkg_resources
+import importlib.metadata
+
+
+# replacement for old pkg_resources
+def importlib_env(search_paths):
+    distributions = {}
+    for path in search_paths:
+        try:
+            for distribution in importlib.metadata.distributions(path=path):
+                distributions[distribution.metadata['Name']] = distribution
+        except Exception as e:
+            print(f"Error processing path {path}: {e}")
+    return distributions
+
 
 if __name__ == "__main__":
     this_dir = os.path.normpath(os.path.abspath(os.path.dirname(__file__)))
@@ -48,7 +61,7 @@ if __name__ == "__main__":
                 "Error: %s does not exist.  Use the setup.py 'build_tests' command to create it." % (
                     test_dir,))
 
-    env = pkg_resources.Environment(search_path=lib_dirs)
+    env = importlib_env(lib_dirs)
 
     distributions = env["nose-py3"]
     if not distributions:

--- a/selftest.py
+++ b/selftest.py
@@ -46,20 +46,13 @@ if __name__ == "__main__":
     this_dir = os.path.normpath(os.path.abspath(os.path.dirname(__file__)))
     lib_dirs = [this_dir]
     test_dir = this_dir
-    if sys.version_info >= (3,):
-        # Under Python 3.x, we need to 'build' the source (using 2to3, etc)
-        # first.  'python3 setup.py build_tests' will put everything under
-        # build/tests (including nose itself, since some tests are inside the
-        # nose source)
-        # The 'py3where' argument in setup.cfg will take care of making sure we
-        # pull our tests only from the build/tests directory.  We just need to
-        # make sure the right things are on sys.path.
-        lib_dirs = glob.glob(os.path.join(this_dir, 'build', 'lib*'))
-        test_dir = os.path.join(this_dir, 'build', 'tests')
-        if not os.path.isdir(test_dir):
-            raise Exception(
-                "Error: %s does not exist.  Use the setup.py 'build_tests' command to create it." % (
-                    test_dir,))
+
+    lib_dirs = glob.glob(os.path.join(this_dir, 'build', 'lib*'))
+    test_dir = os.path.join(this_dir, 'build', 'tests')
+    if not os.path.isdir(test_dir):
+        raise Exception(
+            "Error: %s does not exist.  Use the setup.py 'build_tests' command to create it." % (
+                test_dir,))
 
     env = importlib_env(lib_dirs)
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ try:
                 'nosetests = nose:run_exit',
                 'nosetests%s = nose:run_exit' % py_vers_tag,
             ],
-            'distutils.commands': [
+            'setuptools.commands': [
                 ' nosetests = nose.commands:nosetests',
             ],
         },
@@ -76,7 +76,7 @@ try:
 except ImportError:
     import re
     from setuptools.command.easy_install import easy_install
-    from distutils.core import setup
+    from setuptools import setup
     from setup3lib import setup
     from setuptools import find_packages
 

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 import os
 import sys
 
-VERSION = '1.6.3'
+VERSION = '1.6.4'
 py_vers_tag = '-%s.%s' % sys.version_info[:2]
 
 test_dirs = ['functional_tests', 'unit_tests', os.path.join('doc', 'doc_tests'), 'nose']
 
-if sys.version_info >= (3, 6):
+if sys.version_info >= (3, 9):
     try:
         import setuptools
     except ImportError:
@@ -97,7 +97,8 @@ setup(
         'coverage', 
         'six', 
         'sphinx',
-        '2to3'
+        'setuptools',
+        'logging'
         ],
     description='nose extends unittest to make testing easier - python3 version',
     long_description=
@@ -137,6 +138,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Topic :: Software Development :: Testing'
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.9',
     **addl_args
 )

--- a/setup3lib.py
+++ b/setup3lib.py
@@ -19,10 +19,10 @@ else:
     import re
     import logging
     from setuptools import Distribution as _Distribution
-    from distutils.core import Command
-    from distutils import dir_util, file_util, log
+    from setuptools import Command
+    from setuptools._distutils import dir_util, file_util, log
     import setuptools.command.test
-    from pkg_resources import normalize_path
+    from importlib.metadata import normalize_path
 
     try:
         import patch

--- a/setup3lib.py
+++ b/setup3lib.py
@@ -35,9 +35,9 @@ else:
 
 
     def pyversion_patch(filename):
-        '''Find the best pyversion-fixup patch for a given filename and apply
+        """Find the best pyversion-fixup patch for a given filename and apply
            it.
-        '''
+        """
         dir, file = os.path.split(filename)
         best_ver = (0,)
         patchfile = None
@@ -127,7 +127,8 @@ else:
                         pyversion_patch(file)
                 else:
                     log.warn(
-                        "Warning: pyversion_patching specified in setup config but patch module not found.  Patching will not be performed.")
+                        "Warning: pyversion_patching specified in setup config but patch module not found.  Patching "
+                        "will not be performed.")
 
             dir_util.mkpath(lib_base)
             self.reinitialize_command('egg_info', egg_base=lib_base)

--- a/setup3lib.py
+++ b/setup3lib.py
@@ -1,150 +1,129 @@
+import logging
+import os
+import re
+import shutil
 import sys
 
+import setuptools.command.test
+from setuptools import Command
+from setuptools import Distribution as _Distribution
 from setuptools import setup as _setup
 
-py3_args = ['use_2to3', 'convert_2to3_doctests', 'use_2to3_fixers', 'test_dirs', 'test_build_dir',
-            'doctest_exts', 'pyversion_patching']
+import patch
 
-if sys.version_info < (3,):
-    # Remove any Python-3.x-only arguments (so they don't generate complaints
-    # from 2.x setuptools) and then just pass through to the regular setup
-    # routine.
-    def setup(*args, **kwargs):
-        for a in py3_args:
-            if a in kwargs:
-                del kwargs[a]
-        return _setup(*args, **kwargs)
-else:
-    import os
-    import re
-    import logging
-    from setuptools import Distribution as _Distribution
-    from setuptools import Command
-    from setuptools._distutils import dir_util, file_util, log
-    import setuptools.command.test
-    from importlib.metadata import normalize_path
+py3_args = ['test_dirs', 'test_build_dir', 'doctest_exts', 'pyversion_patching']
+patch.logger.setLevel(logging.WARN)
+patchfile_re = re.compile(r'(.*)\.py([0-9.]+)\.patch$')
 
+
+def pyversion_patch(filename):
+    """
+    :param filename:
+    :return:
+    Find the best pyversion-fixup patch for a given filename and apply it.
+    """
+    dir, file = os.path.split(filename)
+    best_ver = (0,)
+    patchfile = None
+    for dirfile in os.listdir(dir):
+        m = patchfile_re.match(dirfile)
+        if not m:
+            continue
+        base, ver = m.groups()
+        if base != file:
+            continue
+        ver = tuple([int(v) for v in ver.split('.')])
+        if sys.version_info >= ver and ver > best_ver:
+            best_ver = ver
+            patchfile = dirfile
+    if not patchfile:
+        return False
+    logging.info("Applying %s to %s..." % (patchfile, filename))
+    cwd = os.getcwd()
+    os.chdir(dir)
     try:
-        import patch
-
-        patch.logger.setLevel(logging.WARN)
-    except ImportError:
-        patch = None
-
-    patchfile_re = re.compile(r'(.*)\.py([0-9.]+)\.patch$')
+        p = patch.fromfile(patchfile)
+        p.apply()
+    finally:
+        os.chdir(cwd)
+    return True
 
 
-    def pyversion_patch(filename):
-        """Find the best pyversion-fixup patch for a given filename and apply
-           it.
-        """
-        dir, file = os.path.split(filename)
-        best_ver = (0,)
-        patchfile = None
-        for dirfile in os.listdir(dir):
-            m = patchfile_re.match(dirfile)
-            if not m:
-                continue
-            base, ver = m.groups()
-            if base != file:
-                continue
-            ver = tuple([int(v) for v in ver.split('.')])
-            if sys.version_info >= ver and ver > best_ver:
-                best_ver = ver
-                patchfile = dirfile
-        if not patchfile:
-            return False
-        log.info("Applying %s to %s..." % (patchfile, filename))
-        cwd = os.getcwd()
-        os.chdir(dir)
-        try:
-            p = patch.fromfile(patchfile)
-            p.apply()
-        finally:
-            os.chdir(cwd)
-        return True
+class Distribution(_Distribution):
+    def __init__(self, attrs=None):
+        self.test_dirs = []
+        self.test_build_dir = None
+        self.doctest_exts = ['.py', '.rst']
+        self.pyversion_patching = False
+        _Distribution.__init__(self, attrs)
 
 
-    class Distribution(_Distribution):
-        def __init__(self, attrs=None):
-            self.test_dirs = []
-            self.test_build_dir = None
-            self.doctest_exts = ['.py', '.rst']
-            self.pyversion_patching = False
-            _Distribution.__init__(self, attrs)
+class BuildTestsCommand(Command):
+    user_options = []
+
+    def initialize_options(self):
+        self.test_base = None
+
+    def finalize_options(self):
+        test_base = self.distribution.test_build_dir
+        if not test_base:
+            bcmd = self.get_finalized_command('build')
+            test_base = bcmd.build_base
+        self.test_base = test_base
+
+    def run(self):
+        test_dirs = getattr(self.distribution, 'test_dirs', [])
+        test_base = self.test_base
+        bpy_cmd = self.get_finalized_command("build_py")
+        lib_base = os.path.normpath(bpy_cmd.build_lib)
+        modified = []
+        py_modified = []
+        doc_modified = []
+        os.makedirs(test_base)
+        for testdir in test_dirs:
+            for srcdir, dirnames, filenames in os.walk(testdir):
+                destdir = os.path.join(test_base, srcdir)
+                os.makedirs(destdir)
+                for fn in filenames:
+                    if fn.startswith("."):
+                        # Skip .svn folders and such
+                        continue
+                    dstfile, copied = shutil.copyfile(
+                        os.path.join(srcdir, fn),
+                        os.path.join(destdir, fn))
+                    if copied:
+                        modified.append(dstfile)
+                        if fn.endswith('.py'):
+                            py_modified.append(dstfile)
+                        for ext in self.distribution.doctest_exts:
+                            if fn.endswith(ext):
+                                doc_modified.append(dstfile)
+                                break
+
+        if self.distribution.pyversion_patching:
+            if patch is not None:
+                for file in modified:
+                    pyversion_patch(file)
+            else:
+                logging.warn(
+                    "Warning: pyversion_patching specified in setup config but patch module not found.  Patching "
+                    "will not be performed.")
+
+        os.makedirs(lib_base)
+        self.reinitialize_command('egg_info', egg_base=lib_base)
+        self.run_command('egg_info')
 
 
-    class BuildTestsCommand(Command):
-        # Create mirror copy of tests, convert all .py files using 2to3
-        user_options = []
-
-        def initialize_options(self):
-            self.test_base = None
-
-        def finalize_options(self):
-            test_base = self.distribution.test_build_dir
-            if not test_base:
-                bcmd = self.get_finalized_command('build')
-                test_base = bcmd.build_base
-            self.test_base = test_base
-
-        def run(self):
-            use_2to3 = getattr(self.distribution, 'use_2to3', False)
-            test_dirs = getattr(self.distribution, 'test_dirs', [])
-            test_base = self.test_base
-            bpy_cmd = self.get_finalized_command("build_py")
-            lib_base = normalize_path(bpy_cmd.build_lib)
-            modified = []
-            py_modified = []
-            doc_modified = []
-            dir_util.mkpath(test_base)
-            for testdir in test_dirs:
-                for srcdir, dirnames, filenames in os.walk(testdir):
-                    destdir = os.path.join(test_base, srcdir)
-                    dir_util.mkpath(destdir)
-                    for fn in filenames:
-                        if fn.startswith("."):
-                            # Skip .svn folders and such
-                            continue
-                        dstfile, copied = file_util.copy_file(
-                            os.path.join(srcdir, fn),
-                            os.path.join(destdir, fn),
-                            update=True)
-                        if copied:
-                            modified.append(dstfile)
-                            if fn.endswith('.py'):
-                                py_modified.append(dstfile)
-                            for ext in self.distribution.doctest_exts:
-                                if fn.endswith(ext):
-                                    doc_modified.append(dstfile)
-                                    break
-            if use_2to3:
-                self.run_2to3(py_modified)
-                self.run_2to3(doc_modified, True)
-            if self.distribution.pyversion_patching:
-                if patch is not None:
-                    for file in modified:
-                        pyversion_patch(file)
-                else:
-                    log.warn(
-                        "Warning: pyversion_patching specified in setup config but patch module not found.  Patching "
-                        "will not be performed.")
-
-            dir_util.mkpath(lib_base)
-            self.reinitialize_command('egg_info', egg_base=lib_base)
-            self.run_command('egg_info')
+class TestCommand(setuptools.command.test.test):
+    # Override 'test' command to make sure 'build_tests' gets run first.
+    def run(self):
+        self.run_command('build_tests')
+        setuptools.command.test.test.run(self)
 
 
-    class TestCommand(setuptools.command.test.test):
-        # Override 'test' command to make sure 'build_tests' gets run first.
-        def run(self):
-            self.run_command('build_tests')
-            setuptools.command.test.test.run(self)
-
-
-    def setup(*args, **kwargs):
-        kwargs.setdefault('distclass', Distribution)
-        cmdclass = kwargs.setdefault('cmdclass', {})
-        cmdclass.setdefault('build_tests', BuildTestsCommand)
-        cmdclass.setdefault('test', TestCommand)
-        return _setup(*args, **kwargs)
+def setup(*args, **kwargs):
+    kwargs.setdefault('distclass', Distribution)
+    cmdclass = kwargs.setdefault('cmdclass', {})
+    cmdclass.setdefault('build_tests', BuildTestsCommand)
+    cmdclass.setdefault('test', TestCommand)
+    return _setup(*args, **kwargs)

--- a/unit_tests/mock.py
+++ b/unit_tests/mock.py
@@ -1,13 +1,18 @@
-import imp
 import sys
+import types
 
 from nose import proxy
 from nose.plugins.manager import NoPlugins
 from nose.util import odict
 
 
+# replacement with new function wrapper
+def new_module(name):
+    return types.ModuleType(name)
+
+
 def mod(name):
-    m = imp.new_module(name)
+    m = new_module(name)
     sys.modules[name] = m
     return m
 
@@ -103,7 +108,7 @@ class Bucket(object):
         self.__dict__['d'].update(kw)
 
     def __getattr__(self, attr):
-        if 'd' not in self.__dict__
+        if 'd' not in self.__dict__:
             return None
         return self.__dict__['d'].get(attr)
 

--- a/unit_tests/support/doctest/noname_wrapper.py
+++ b/unit_tests/support/doctest/noname_wrapper.py
@@ -1,13 +1,29 @@
+import importlib
+import importlib.util
+import sys, os
+
+
+# replacement with new importlib function wrapper
+def load_source(name, filepath):
+    spec = importlib.util.spec_from_file_location(name, filepath)
+    if spec is None:
+        raise ImportError(f"Error: Can not load the module {name} from {filepath}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    sys.modules[name] = module
+    return module
+
+
 def __bootstrap__():
     """ Import the code in ``noname_wrapped.not_py`` in file as our own name
 
     This is a simplified version of the wrapper that setuptools writes for
     dynamic libraries when installing.
     """
-    import os
-    import imp
+
     here = os.path.join(os.path.dirname(__file__))
-    imp.load_source(__name__, os.path.join(here, 'noname_wrapped.not_py'))
+    load_source(__name__, os.path.join(here, 'noname_wrapped.not_py'))
 
 
 __bootstrap__()

--- a/unit_tests/test_deprecated_plugin.py
+++ b/unit_tests/test_deprecated_plugin.py
@@ -5,7 +5,7 @@ from io import StringIO
 
 from nose.config import Config
 from nose.plugins.deprecated import Deprecated, DeprecatedTest
-from nose.result import _TextTestResult
+from nose.result import TextTestResult
 
 try:
     # 2.7+
@@ -24,7 +24,7 @@ class TestDeprecatedPlugin(unittest.TestCase):
 
     def test_prepare_patches_result(self):
         stream = _WritelnDecorator(StringIO())
-        res = _TextTestResult(stream, 0, 1)
+        res = TextTestResult(stream, 0, 1)
         sk = Deprecated()
         sk.prepareTestResult(res)
         res._orig_addError
@@ -77,7 +77,7 @@ class TestDeprecatedPlugin(unittest.TestCase):
                 raise DeprecatedTest('deprecated me')
 
         stream = _WritelnDecorator(StringIO())
-        res = _TextTestResult(stream, 0, 1)
+        res = TextTestResult(stream, 0, 1)
         sk = Deprecated()
         sk.prepareTestResult(res)
 
@@ -98,7 +98,7 @@ class TestDeprecatedPlugin(unittest.TestCase):
                 raise DeprecatedTest('deprecated me too')
 
         stream = _WritelnDecorator(StringIO())
-        res = _TextTestResult(stream, 0, verbosity=2)
+        res = TextTestResult(stream, 0, verbosity=2)
         sk = Deprecated()
         sk.prepareTestResult(res)
         test = TC('test')

--- a/unit_tests/test_loader.py
+++ b/unit_tests/test_loader.py
@@ -1,11 +1,16 @@
-import imp
 import os
 import sys
+import types
 import unittest
 
 import nose.case
 from nose import util, loader, selector  # so we can set mocks
 from nose.loader import TestLoader as Loader
+
+
+# replacement with new function wrapper
+def new_module(name):
+    return types.ModuleType(name)
 
 
 def safepath(p):
@@ -20,22 +25,22 @@ def mods():
     # test loading
     #
     M = {}
-    M['test_module'] = imp.new_module('test_module')
-    M['module'] = imp.new_module('module')
-    M['package'] = imp.new_module('package')
+    M['test_module'] = new_module('test_module')
+    M['module'] = new_module('module')
+    M['package'] = new_module('package')
     M['package'].__path__ = [safepath('/package')]
     M['package'].__file__ = safepath('/package/__init__.py')
-    M['package.subpackage'] = imp.new_module('package.subpackage')
+    M['package.subpackage'] = new_module('package.subpackage')
     M['package'].subpackage = M['package.subpackage']
     M['package.subpackage'].__path__ = [safepath('/package/subpackage')]
     M['package.subpackage'].__file__ = safepath(
         '/package/subpackage/__init__.py')
-    M['test_module_with_generators'] = imp.new_module(
+    M['test_module_with_generators'] = new_module(
         'test_module_with_generators')
-    M['test_module_with_metaclass_tests'] = imp.new_module(
+    M['test_module_with_metaclass_tests'] = new_module(
         'test_module_with_metaclass_tests')
-    M['test_transplant'] = imp.new_module('test_transplant')
-    M['test_module_transplant_generator'] = imp.new_module(
+    M['test_transplant'] = new_module('test_transplant')
+    M['test_module_transplant_generator'] = new_module(
         'test_module_transplant_generator')
 
     # a unittest testcase subclass

--- a/unit_tests/test_multiprocess_runner.py
+++ b/unit_tests/test_multiprocess_runner.py
@@ -1,10 +1,15 @@
-import imp
 import sys
+import types
 import unittest
 
 from nose.loader import TestLoader
 from nose.plugins import multiprocess
 from nose.suite import ContextSuite
+
+
+# replacement with new function wrapper
+def new_module(name):
+    return types.ModuleType(name)
 
 
 class T_fixt:
@@ -40,7 +45,7 @@ class TestMultiProcessTestRunner(unittest.TestCase):
         self.assertEqual(len(tests), 3)
 
     def test_next_batch_with_module_fixt(self):
-        mod_with_fixt = imp.new_module('mod_with_fixt')
+        mod_with_fixt = new_module('mod_with_fixt')
         sys.modules['mod_with_fixt'] = mod_with_fixt
 
         def teardown():
@@ -61,7 +66,7 @@ class TestMultiProcessTestRunner(unittest.TestCase):
         self.assertEqual(len(tests), 1)
 
     def test_next_batch_with_module(self):
-        mod_no_fixt = imp.new_module('mod_no_fixt')
+        mod_no_fixt = new_module('mod_no_fixt')
         sys.modules['mod_no_fixt'] = mod_no_fixt
 
         class Test2(T):
@@ -99,8 +104,7 @@ class TestMultiProcessTestRunner(unittest.TestCase):
         self.assertEqual(len(tests), 1)
 
     def test_next_batch_can_split_set(self):
-
-        mod_with_fixt2 = imp.new_module('mod_with_fixt2')
+        mod_with_fixt2 = new_module('mod_with_fixt2')
         sys.modules['mod_with_fixt2'] = mod_with_fixt2
 
         def setup():

--- a/unit_tests/test_skip_plugin.py
+++ b/unit_tests/test_skip_plugin.py
@@ -5,7 +5,7 @@ from io import StringIO
 
 from nose.config import Config
 from nose.plugins.skip import Skip, SkipTest
-from nose.result import _TextTestResult
+from nose.result import TextTestResult
 
 try:
     # 2.7+
@@ -24,7 +24,7 @@ class TestSkipPlugin(unittest.TestCase):
 
     def test_prepare_patches_result(self):
         stream = _WritelnDecorator(StringIO())
-        res = _TextTestResult(stream, 0, 1)
+        res = TextTestResult(stream, 0, 1)
         sk = Skip()
         sk.prepareTestResult(res)
         res._orig_addError
@@ -75,7 +75,7 @@ class TestSkipPlugin(unittest.TestCase):
                 raise SkipTest('skip me')
 
         stream = _WritelnDecorator(StringIO())
-        res = _TextTestResult(stream, 0, 1)
+        res = TextTestResult(stream, 0, 1)
         sk = Skip()
         sk.prepareTestResult(res)
 
@@ -97,7 +97,7 @@ class TestSkipPlugin(unittest.TestCase):
                 raise SkipTest('skip me too')
 
         stream = _WritelnDecorator(StringIO())
-        res = _TextTestResult(stream, 0, verbosity=2)
+        res = TextTestResult(stream, 0, verbosity=2)
         sk = Skip()
         sk.prepareTestResult(res)
         test = TC('test')

--- a/unit_tests/test_suite.py
+++ b/unit_tests/test_suite.py
@@ -1,5 +1,5 @@
-import imp
 import sys
+import types
 import unittest
 
 from mock import ResultProxyFactory, ResultProxy
@@ -8,6 +8,11 @@ from nose import case
 from nose.config import Config
 from nose.suite import LazySuite, ContextSuite, ContextSuiteFactory, \
     ContextList
+
+
+# replacement with new function wrapper
+def new_module(name):
+    return types.ModuleType(name)
 
 
 class TestLazySuite(unittest.TestCase):
@@ -162,9 +167,9 @@ class TestContextSuite(unittest.TestCase):
         assert context.was_torndown
 
     def test_context_fixtures_for_ancestors(self):
-        top = imp.new_module('top')
-        top.bot = imp.new_module('top.bot')
-        top.bot.end = imp.new_module('top.bot.end')
+        top = new_module('top')
+        top.bot = new_module('top.bot')
+        top.bot.end = new_module('top.bot.end')
 
         sys.modules['top'] = top
         sys.modules['top.bot'] = top.bot
@@ -274,9 +279,9 @@ class TestContextSuite(unittest.TestCase):
 class TestContextSuiteFactory(unittest.TestCase):
 
     def test_ancestry(self):
-        top = imp.new_module('top')
-        top.bot = imp.new_module('top.bot')
-        top.bot.end = imp.new_module('top.bot.end')
+        top = new_module('top')
+        top.bot = new_module('top.bot')
+        top.bot.end = new_module('top.bot.end')
 
         sys.modules['top'] = top
         sys.modules['top.bot'] = top.bot

--- a/unit_tests/test_utils.py
+++ b/unit_tests/test_utils.py
@@ -1,4 +1,5 @@
 import os
+import types
 import unittest
 
 import nose
@@ -8,6 +9,11 @@ from nose import util
 from nose.pyversion import unbound_method
 
 np = os.path.normpath
+
+
+# replacement with new function wrapper
+def new_module(name):
+    return types.ModuleType(name)
 
 
 class TestUtils(unittest.TestCase):
@@ -166,7 +172,6 @@ class TestUtils(unittest.TestCase):
 
     def test_try_run(self):
         try_run = util.try_run
-        import imp
 
         def bar():
             pass
@@ -186,7 +191,7 @@ class TestUtils(unittest.TestCase):
             def method(self):
                 pass
 
-        foo = imp.new_module('foo')
+        foo = new_module('foo')
         foo.bar = bar
         foo.bar_m = bar_m
         foo.i_bar = Bar()

--- a/unit_tests/test_xunit.py
+++ b/unit_tests/test_xunit.py
@@ -86,16 +86,16 @@ class TestTee(unittest.TestCase):
 
     def test_tee_works_with_distutils_log(self):
         try:
-            from distutils.log import Log, DEBUG
+            from setuptools.log import Log, DEBUG
         except ImportError:
-            raise SkipTest("distutils.log not available; skipping")
+            raise SkipTest("setuptools.log not available; skipping")
 
         l = Log(DEBUG)
         try:
             l.warn('Test')
         except Exception as e:
             self.fail(
-                "Exception raised while writing to distutils.log: %s" % (e,))
+                "Exception raised while writing to setuptools.log: %s" % (e,))
 
 
 class TestXMLOutputWithXML(unittest.TestCase):


### PR DESCRIPTION
As of Python 3.12 imp is removed.  This replaces all instances of imp with importlib, types, etc.. to ensure future-proofing.  Needs testing though.