### PR TITLE
Py3 compat

### DIFF
--- a/nose/__init__.py
+++ b/nose/__init__.py
@@ -4,7 +4,7 @@ from nose.plugins.skip import SkipTest
 from nose.tools import with_setup
 
 __author__ = 'Adam Bilbrough'
-__versioninfo__ = (1, 6, 6)
+__versioninfo__ = (1, 6, 7)
 __version__ = '.'.join(map(str, __versioninfo__))
 
 __all__ = [

--- a/nose/importer.py
+++ b/nose/importer.py
@@ -41,10 +41,11 @@ else:
     acquire_lock = _import_lock.acquire
     release_lock = _import_lock.release
 
+
     def find_module(part, path=None):
         spec = find_spec(part, path)
         if spec is None:
-            raise ImportError(f"Error: The Module {part} is not found")
+            raise ImportError(f"Error: The Module {part} is not found at {path}")
 
         filename = spec.origin
         desc = (".py", "U", 1)

--- a/nose/importer.py
+++ b/nose/importer.py
@@ -131,7 +131,12 @@ class Importer(object):
                 acquire_lock()
                 log.debug("find module part %s (%s) in %s",
                           part, part_fqname, path)
-                fh, filename, desc = find_module(part_fqname, path)
+
+                if sys.version_info < (3, 11):
+                    fh, filename, desc = find_module(part, path)
+                else:
+                    fh, filename, desc = find_module(part_fqname, path)
+
                 old = sys.modules.get(part_fqname)
                 if old is not None:
                     # test modules frequently have name overlap; make sure

--- a/nose/importer.py
+++ b/nose/importer.py
@@ -43,9 +43,12 @@ else:
 
 
     def find_module(part, path=None):
+
+        # note: this seems to be a mismatch in types, find_spec takes
+        # a single package name, not a list of path strings
         spec = find_spec(part, path)
         if spec is None:
-            raise ImportError(f"Error: The Module {part} is not found at {path}")
+            raise ImportError(f"Error: The Module {part} is not found")
 
         filename = spec.origin
         desc = (".py", "U", 1)
@@ -89,8 +92,10 @@ class Importer(object):
         # find the base dir of the package
         path_parts = os.path.normpath(os.path.abspath(path)).split(os.sep)
         name_parts = fqname.split('.')
+
         if path_parts[-1] == '__init__.py':
             path_parts.pop()
+
         path_parts = path_parts[:-(len(name_parts))]
         dir_path = os.sep.join(path_parts)
         # then import fqname starting from that dir
@@ -126,7 +131,7 @@ class Importer(object):
                 acquire_lock()
                 log.debug("find module part %s (%s) in %s",
                           part, part_fqname, path)
-                fh, filename, desc = find_module(part, path)
+                fh, filename, desc = find_module(part_fqname, path)
                 old = sys.modules.get(part_fqname)
                 if old is not None:
                     # test modules frequently have name overlap; make sure

--- a/nose/importer.py
+++ b/nose/importer.py
@@ -38,7 +38,7 @@ else:
     from threading import Lock
 
     _import_lock = Lock()
-    acquire_lock = _import_lock.aquire
+    acquire_lock = _import_lock.acquire
     release_lock = _import_lock.release
 
     def find_module(part, path=None):

--- a/nose/plugins/manager.py
+++ b/nose/plugins/manager.py
@@ -344,16 +344,15 @@ class ZeroNinePlugin:
         return getattr(self.plugin, val)
 
 
-def _iter_entry_points(ep_name):
-    if sys.version_info < (3, 11):
-        # pkg_resources is deprecated from 3.11 onwards
-        from pkg_resources import iter_entry_points
-        yield from iter_entry_points(ep_name)
+if sys.version_info < (3, 11):
+    # pkg_resources is deprecated from 3.11 onwards
+    from pkg_resources import iter_entry_points
 
-    else:
-        # this API is unstable prior to 3.11, so do not use it
-        from importlib.metadata import entry_points
-        yield from entry_points(group=ep_name)
+else:
+    # this API is unstable prior to 3.11, so do not use it
+    from importlib.metadata import entry_points as _entry_points
+    def iter_entry_points(group):
+        return _entry_points(group=group)
 
 
 class EntryPointPluginManager(PluginManager):
@@ -369,7 +368,7 @@ class EntryPointPluginManager(PluginManager):
         loaded = {}
 
         for entry_point, adapt in self.entry_points:
-            for ep in _iter_entry_points(entry_point):
+            for ep in iter_entry_points(entry_point):
                 if ep.name in loaded:
                     continue
                 else:

--- a/setup.py
+++ b/setup.py
@@ -103,20 +103,20 @@ setup(
     long_description=
     """nose extends the test loading and running features of unittest, making
         it easier to write, find and run tests.
-    
+
         By default, nose will run tests in files or directories under the current
         working directory whose names include "test" or "Test" at a word boundary
         (like "test_this" or "functional_test" or "TestClass" but not
         "libtest"). Test output is similar to that of unittest, but also includes
         captured stdout output from failing tests, for easy print-style debugging.
-    
+
         These features, and many more, are customizable through the use of
         plugins. Plugins included with nose provide support for doctest, code
         coverage and profiling, flexible attribute-based test selection,
         output capture and more. More information about writing plugins may be
         found on in the nose API documentation, here:
         http://readthedocs.org/docs/nose/
-    
+
         If you have recently reported a bug marked as fixed, or have a craving for
         the very latest, you may want the development version instead:
         https://github.com/atsb/nose-py3
@@ -137,6 +137,5 @@ setup(
         'Programming Language :: Python :: 3',
         'Topic :: Software Development :: Testing'
     ],
-    python_requires='>=3.12',
     **addl_args
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-VERSION = '1.6.6'
+VERSION = '1.6.7'
 py_vers_tag = '-%s.%s' % sys.version_info[:2]
 
 test_dirs = ['functional_tests', 'unit_tests', os.path.join('doc', 'doc_tests'), 'nose']


### PR DESCRIPTION
This re-enables compatibility with earlier versions of Python. I've personally tested this on the range of 3.7 through 3.11 (I need to get a test env for 3.12 still). I've gated most everything on a version check, so earlier than 3.11 works in the old way (pkg_resources and imp) and 3.11+ works with the new way (importlib).

I also pre-bumped the version values to 1.6.7

Closes #18 