### PR TITLE
safer safe_str

### DIFF
--- a/nose/util.py
+++ b/nose/util.py
@@ -655,7 +655,7 @@ def safe_str(val, encoding='utf-8'):
         return val.decode(encoding, errors='replace')
     elif isinstance(val, Exception):
         return ' '.join([safe_str(arg, encoding)
-                         for arg in val])
+                         for arg in val.args])
     else:
         try:
             return str(val)


### PR DESCRIPTION
I copied some of the original safe_str from the old code, and something I didn't immediately notice was that it attempted to directly iterate over the exception (when the val was an exception instance). This may have worked in py2 (did it?) but in py3 we more likely need to iterate over the exceptions `args` attribute. I've made that tweak here.