### PR TITLE
Fix some unescaped \ in docstrings

### DIFF
--- a/nose/config.py
+++ b/nose/config.py
@@ -143,7 +143,7 @@ class ConfiguredDefaultsOptionParser(object):
 
 
 class Config(object):
-    """nose configuration.
+    r"""nose configuration.
 
     Instances of Config are used throughout nose to configure
     behavior, including plugin lists. Here are the default values for

--- a/nose/inspector.py
+++ b/nose/inspector.py
@@ -105,8 +105,8 @@ def tbsource(tb, context=6):
 
 
 def find_inspectable_lines(lines, pos):
-    """Find lines in home that are inspectable.
-    
+    r"""Find lines in home that are inspectable.
+
     Walk back from the err line up to 3 lines, but don't walk back over
     changes in indent level.
 


### PR DESCRIPTION
Either the \ needs to be escaped, or the string needs to be a raw string. The latter makes the docstring look better when reading the source code.