### PR TITLE
Make sure module is in sys.modules before executing it

### DIFF
--- a/nose/importer.py
+++ b/nose/importer.py
@@ -67,8 +67,8 @@ else:
             raise ImportError(f"Error: Can not load the module {module_name}")
 
         module = module_from_spec(spec)
-        spec.loader.exec_module(module)
         sys.modules[module_name] = module
+        spec.loader.exec_module(module)
 
         return module
 


### PR DESCRIPTION
Otherwise, code looking for the module when it's being executed will fail.