### PR TITLE
Add method addDuration to ResultProxy/Plugin

### DIFF
--- a/nose/plugins/base.py
+++ b/nose/plugins/base.py
@@ -690,6 +690,17 @@ class IPluginInterface(object):
         """
         pass
 
+    def addDuration(self, test, duration):
+        """Called when a test finished to run, regardless of its outcome.
+
+        :param test: the test case
+        :type test: :class:`nose.case.Test`
+        :param duration: the time represented in seconds, and it includes the
+                         execution of cleanup functions.
+        :type duration: float
+        """
+        pass
+
     def testName(self, test):
         """Return a short test name. Called by `nose.case.Test.__str__`.
 

--- a/nose/proxy.py
+++ b/nose/proxy.py
@@ -181,6 +181,11 @@ class ResultProxy(object):
         self.plugins.stopTest(self.test)
         self.result.stopTest(self.test)
 
+    def addDuration(self, test, duration):
+        self.assertMyTest(test)
+        self.plugins.addDuration(self.test, duration)
+        self.result.addDuration(self.test, duration)
+
     # proxied attributes
     shouldStop = proxied_attribute('result', 'shouldStop',
                                    """Should the test run stop?""")


### PR DESCRIPTION
Python 3.12+ calls this after each test

fixes #24 